### PR TITLE
Auth에 대한 테스트 코드를 추가로 작성

### DIFF
--- a/src/main/java/com/hibitbackendrefactor/auth/domain/AuthToken.java
+++ b/src/main/java/com/hibitbackendrefactor/auth/domain/AuthToken.java
@@ -1,5 +1,7 @@
 package com.hibitbackendrefactor.auth.domain;
 
+import com.hibitbackendrefactor.auth.exception.NotFoundTokenException;
+
 public class AuthToken {
 
     private Long id;
@@ -22,5 +24,11 @@ public class AuthToken {
 
     public String getRefreshToken() {
         return refreshToken;
+    }
+
+    public void validateHasSameRefreshToken(final String otherRefreshToken) {
+        if (!refreshToken.equals(otherRefreshToken)) {
+            throw new NotFoundTokenException("회원의 리프레시 토큰이 아닙니다.");
+        }
     }
 }

--- a/src/test/java/com/hibitbackendrefactor/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/application/AuthServiceTest.java
@@ -1,0 +1,107 @@
+package com.hibitbackendrefactor.auth.application;
+
+
+import com.hibitbackendrefactor.auth.domain.TokenRepository;
+import com.hibitbackendrefactor.auth.dto.request.TokenRenewalRequest;
+import com.hibitbackendrefactor.auth.dto.response.AccessTokenResponse;
+import com.hibitbackendrefactor.auth.event.MemberSavedEvent;
+import com.hibitbackendrefactor.auth.exception.InvalidTokenException;
+import com.hibitbackendrefactor.config.ExternalApiConfig;
+import com.hibitbackendrefactor.member.domain.Member;
+import com.hibitbackendrefactor.member.domain.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import java.util.List;
+
+import static com.hibitbackendrefactor.common.AuthFixtures.MEMBER_이메일;
+import static com.hibitbackendrefactor.common.OAuthFixtures.MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(classes = ExternalApiConfig.class)
+@ActiveProfiles("test")
+@RecordApplicationEvents // 없으면 실패뜸 -> 이유 확인
+class AuthServiceTest  {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private ApplicationEvents events;
+    @AfterEach
+    void tearDown() {
+        tokenRepository.deleteAll();
+    }
+
+    @DisplayName("토큰 생성을 하면 OAuth 서버에서 인증 후 토큰을 반환한다")
+    @Test
+    void 토큰_생성을_하면_OAuth_서버에서_인증_후_토큰들을_반환한다() {
+        // given & when
+        AccessTokenResponse actual = authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
+
+        // then
+        assertAll(() -> {
+            assertThat(actual.getAccessToken()).isNotEmpty();
+            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
+        });
+    }
+
+    // 실패 이유 -> 찾아보기
+    @DisplayName("Authorization Code를 받으면 회원이 데이터베이스에 저장된다.")
+    @Test
+    void Authorization_Code를_받으면_회원이_데이터베이스에_저장된다() {
+        // given & when
+        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
+
+        // then
+        assertThat(memberRepository.existsByEmail(MEMBER_이메일)).isTrue();
+
+        assertAll(() -> {
+            // SutbOAuthClient가 반환하는 OAuthMember의 이메일
+            assertThat(memberRepository.existsByEmail(MEMBER_이메일)).isTrue();
+            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("이미 가입된 회원에 대한 Authorization Code를 전달받으면 추가로 회원이 생성되지 않는다")
+    @Test
+    void 이미_가입된_회원에_대한_Authorization_Code를_전달받으면_추가로_회원이_생성되지_않는다() {
+        // 이미 가입된 회원이 소셜 로그인 버튼을 클릭했을 경우엔 회원가입 과정이 생략되고, 곧바로 access token이 발급되어야 한다.
+
+        // given
+        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
+
+        // when
+        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
+        List<Member> actual = memberRepository.findAll();
+
+        // then
+        assertThat(actual).hasSize(1);
+    }
+
+    @DisplayName("리프레시 토큰으로 새로운 엑세스 토큰을 발급 할 때, 리프레시 토큰이 존재하지 않으면 예외를 던진다.")
+    @Test
+    void 리프레시_토큰으로_새로운_엑세스_토큰을_발급_할_때_리프레시_토큰이_존재하지_않으면_예외를_던진다() {
+        // given
+        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
+        TokenRenewalRequest tokenRenewalRequest = new TokenRenewalRequest("DummyRefreshToken");
+
+        // when & then
+        assertThatThrownBy(() -> authService.generateAccessToken(tokenRenewalRequest))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/application/AuthTokenCreatorTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/application/AuthTokenCreatorTest.java
@@ -1,0 +1,69 @@
+package com.hibitbackendrefactor.auth.application;
+
+import com.hibitbackendrefactor.auth.domain.AuthAccessToken;
+import com.hibitbackendrefactor.auth.domain.AuthToken;
+import com.hibitbackendrefactor.auth.domain.TokenRepository;
+import com.hibitbackendrefactor.config.ExternalApiConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = ExternalApiConfig.class)
+@ActiveProfiles("test")
+class AuthTokenCreatorTest {
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private TokenCreator tokenCreator;
+
+
+    @DisplayName("엑세스 토큰과 리프레시 토큰을 발급한다.")
+    @Test
+    void 엑세스_토큰과_리프레시_토큰을_발급한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        AuthToken authToken = tokenCreator.createAuthToken(memberId);
+
+        // then
+        assertThat(authToken.getAccessToken()).isNotEmpty();
+        assertThat(authToken.getRefreshToken()).isNotEmpty();
+    }
+
+    @DisplayName("리프레시 토큰으로 엑세스 토큰을 발급한다.")
+    @Test
+    void 리프레시_토큰으로_엑세스_토큰을_발급한다() {
+        // given
+        Long memberId = 1L;
+        AuthToken authToken = tokenCreator.createAuthToken(memberId);
+
+        // when
+        AuthAccessToken actual = tokenCreator.renewAuthToken(authToken.getRefreshToken());
+
+        // then
+        assertThat(actual.getAccessToken()).isNotEmpty();
+    }
+
+    @DisplayName("토큰에서 페이로드를 추출한다.")
+    @Test
+    void 토큰에서_페이로드를_추출한다() {
+        // given
+        Long memberId = 1L;
+        AuthToken authToken = tokenCreator.createAuthToken(memberId);
+
+        // when
+        Long actual = tokenCreator.extractPayLoad(authToken.getAccessToken());
+
+        // then
+        assertThat(actual).isEqualTo(memberId);
+    }
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/domain/AuthTokenTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/domain/AuthTokenTest.java
@@ -1,0 +1,32 @@
+package com.hibitbackendrefactor.auth.domain;
+
+import com.hibitbackendrefactor.auth.exception.NotFoundTokenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthTokenTest {
+
+    @DisplayName("같은 리프레시 토큰 값이면 정상적으로 메서드를 종료한다.")
+    @Test
+    void 같은_리프레시_토큰_값이면_정상적으로_메서드를_종료한다() {
+        // given
+        AuthToken authToken = new AuthToken(1L, "dummyAccessToken", "dummyRefreshToken");
+
+        // when & then
+        authToken.validateHasSameRefreshToken(authToken.getRefreshToken());
+    }
+
+    @DisplayName("같은 리프레시 토큰 값이 아니면 예외를 발생한다.")
+    @Test
+    void 같은_리프레시_토큰_값이_아니면_예외를_발생한다() {
+        // given
+        AuthToken authToken = new AuthToken(1L, "dummyAccessToken", "dummyRefreshToken");
+
+        // when & then
+        assertThatThrownBy(() -> authToken.validateHasSameRefreshToken("invalidRefreshToken"))
+                .isInstanceOf(NotFoundTokenException.class);
+    }
+
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/domain/InMemoryAuthTokenRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/domain/InMemoryAuthTokenRepositoryTest.java
@@ -1,7 +1,5 @@
-package com.hibitbackendrefactor.auth.repository;
+package com.hibitbackendrefactor.auth.domain;
 
-import com.hibitbackendrefactor.auth.domain.InMemoryAuthTokenRepository;
-import com.hibitbackendrefactor.auth.domain.TokenRepository;
 import com.hibitbackendrefactor.auth.exception.NotFoundTokenException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.hibitbackendrefactor.auth.domain;
+
+import com.hibitbackendrefactor.global.config.JpaAuditingConfig;
+import com.hibitbackendrefactor.member.domain.Member;
+import com.hibitbackendrefactor.member.domain.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
+import static com.hibitbackendrefactor.common.fixtures.OAuthTokenFixtures.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@ActiveProfiles("test")
+class OAuthTokenRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OAuthTokenRepository oAuthTokenRepository;
+
+    @DisplayName("member id의 OAuthToken이 존재할 경우 true를 반환한다.")
+    @Test
+    void member_id의_OAuthToken이_존재할_경우_true를_반환한다() {
+        // given
+        Member 팬시 = memberRepository.save(팬시());
+        oAuthTokenRepository.save(new OAuthToken(팬시, REFRESH_TOKEN));
+
+        // when
+        boolean actual = oAuthTokenRepository.existsByMemberId(팬시.getId());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("member id의 OAuthToken이 존재하지 않을 경우 false를 반환한다.")
+    @Test
+    void member_id의_OAuthToken이_존재하지_않을_경우_false를_반환한다() {
+        // given & when
+        boolean actual = oAuthTokenRepository.existsByMemberId(1L);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @DisplayName("member id의 OAuthToken이 존재할 경우 Optional은 비어있지 않다.")
+    @Test
+    void member_id의_OAuthToken이_존재할_경우_Optional은_비어있지_않다() {
+        // given
+        Member 팬시 = memberRepository.save(팬시());
+        oAuthTokenRepository.save(new OAuthToken(팬시, REFRESH_TOKEN));
+
+        // when
+        Optional<OAuthToken> actual = oAuthTokenRepository.findByMemberId(팬시.getId());
+
+        // then
+        assertThat(actual).isNotEmpty();
+    }
+
+    @DisplayName("member id의 OAuthToken이 존재하지 않을 경우 비어있다.")
+    @Test
+    void member_id의_OAuthToken이_존재하지_않을_경우_비어있다() {
+        // given & when
+        Optional<OAuthToken> actual = oAuthTokenRepository.findByMemberId(1L);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenTest.java
@@ -1,0 +1,38 @@
+package com.hibitbackendrefactor.auth.domain;
+
+import com.hibitbackendrefactor.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class OAuthTokenTest {
+    @DisplayName("OAuth token을 생성한다.")
+    @Test
+    void OAuth_token을_생성한다() {
+        // given
+        Member 팬시 = 팬시();
+        String refreshToken = "refreshToken";
+
+        // when & then
+        assertDoesNotThrow(() -> new OAuthToken(팬시, refreshToken));
+    }
+    @DisplayName("refresh token을 교체한다.")
+    @Test
+    void refresh_token을_교체한다() {
+        // given
+        Member 팬시 = 팬시();
+        String refreshToken = "refreshToken";
+        OAuthToken oAuthToken = new OAuthToken(팬시, refreshToken);
+
+        String updatedRefreshToken = "updateRefreshToekn";
+
+        // when
+        oAuthToken.change(updatedRefreshToken);
+
+        // then
+        assertThat(oAuthToken.getRefreshToken()).isEqualTo(updatedRefreshToken);
+    }
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package com.hibitbackendrefactor.auth.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hibitbackendrefactor.auth.application.AuthService;
+import com.hibitbackendrefactor.auth.application.OAuthUri;
+import com.hibitbackendrefactor.config.ExternalApiConfig;
+import com.hibitbackendrefactor.member.application.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.hibitbackendrefactor.common.AuthFixtures.GOOGLE_PROVIDER;
+import static com.hibitbackendrefactor.common.AuthFixtures.OAuth_로그인_링크;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(ExternalApiConfig.class)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected OAuthUri oAuthUri;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @DisplayName("OAuth 소셜 로그인을 위한 링크와 상태코드 200을 반환한다.")
+    @Test
+    void OAuth_소셜_로그인을_위한_링크와_상태코드_200을_반환한다() throws Exception {
+        // given
+        given(oAuthUri.generate(any())).willReturn(OAuth_로그인_링크);
+
+        // when & then
+        mockMvc.perform(get("/api/auth/{oauthProvider}/oauth-uri?redirectUri={redirectUri}", GOOGLE_PROVIDER,
+                        "https://hibit.com/oauth"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/hibitbackendrefactor/common/AuthFixtures.java
+++ b/src/test/java/com/hibitbackendrefactor/common/AuthFixtures.java
@@ -1,5 +1,9 @@
 package com.hibitbackendrefactor.common;
 
+import com.hibitbackendrefactor.auth.dto.request.TokenRenewalRequest;
+import com.hibitbackendrefactor.auth.dto.request.TokenRequest;
+import com.hibitbackendrefactor.auth.dto.response.AccessAndRefreshTokenResponse;
+
 public class AuthFixtures {
 
     public static final String GOOGLE_PROVIDER = "google";
@@ -9,10 +13,24 @@ public class AuthFixtures {
     public static final String STUB_MEMBER_REFRESH_인증_코드 = "member refresh authorization code";
     public static final String STUB_CREATOR_인증_코드 = "creator authorization code";
 
+    public static final String 더미_엑세스_토큰 = "aaaaa.bbbbb.ccccc";
+    public static final String 더미_리프레시_토큰 = "ccccc.bbbbb.aaaaa";
+    public static final String OAuth_로그인_링크 = "https://accounts.google.com/o/oauth2/v2/auth";
     public static final String MEMBER_이메일 = "member@email.com";
 
     public static final String 더미_시크릿_키 = "asdfasarspofjkosdfasdjkflikasndflkasndsdfjkadsnfkjasdn";
 
     public static final String STUB_OAUTH_ACCESS_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc";
 
+    public static TokenRequest MEMBER_인증_코드_토큰_요청() {
+        return new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
+    }
+
+    public static AccessAndRefreshTokenResponse MEMBER_인증_코드_토큰_응답() {
+        return new AccessAndRefreshTokenResponse(1L, STUB_MEMBER_인증_코드, STUB_MEMBER_REFRESH_인증_코드);
+    }
+
+    public static TokenRenewalRequest MEMBER_리뉴얼_토큰_요청() {
+        return new TokenRenewalRequest(더미_리프레시_토큰);
+    }
 }

--- a/src/test/java/com/hibitbackendrefactor/common/fixtures/OAuthTokenFixtures.java
+++ b/src/test/java/com/hibitbackendrefactor/common/fixtures/OAuthTokenFixtures.java
@@ -1,0 +1,6 @@
+package com.hibitbackendrefactor.common.fixtures;
+
+public class OAuthTokenFixtures {
+    public static final String REFRESH_TOKEN = "qwerasdfzxcv";
+
+}


### PR DESCRIPTION
- [ ] 💯 테스트는 통과했나? -> 1개 실패
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

Closes #27 

## 주의사항

- AuthServiceTest 에서 `Authorization_Code를_받으면_회원이_데이터베이스에_저장된다` 메서드에 대한 테스트 실패가 뜬다.
  - 단독으로 돌리면 성공이 되고, 전체 테스트를 돌리면 실패가 뜬다.
  - 이 문제는 추후에 이슈로 생성해서 해결해보자.
