### PR TITLE
 테스트 수행시 서버 횟수를 줄이기 위해 테스트 환경을 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    //테스트에서 lombok 사용
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/test/java/com/hibitbackendrefactor/ControllerTestSupport.java
+++ b/src/test/java/com/hibitbackendrefactor/ControllerTestSupport.java
@@ -8,6 +8,10 @@ import com.hibitbackendrefactor.config.ExternalApiConfig;
 import com.hibitbackendrefactor.member.application.MemberService;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.member.presentation.MemberController;
+import com.hibitbackendrefactor.post.application.PostService;
+import com.hibitbackendrefactor.post.presentation.PostController;
+import com.hibitbackendrefactor.profile.application.ProfileService;
+import com.hibitbackendrefactor.profile.presentation.ProfileController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,7 +21,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
         MemberController.class,
-        AuthController.class
+        AuthController.class,
+        ProfileController.class,
+        PostController.class
 })
 @Import(ExternalApiConfig.class)
 @ActiveProfiles("test")
@@ -39,4 +45,10 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected MemberRepository memberRepository;
+
+    @MockBean
+    protected ProfileService profileService;
+
+    @MockBean
+    protected PostService postService;
 }

--- a/src/test/java/com/hibitbackendrefactor/HibitBackendRefactorApplicationTests.java
+++ b/src/test/java/com/hibitbackendrefactor/HibitBackendRefactorApplicationTests.java
@@ -1,3 +1,4 @@
+/*
 package com.hibitbackendrefactor;
 
 import org.junit.jupiter.api.Test;
@@ -11,3 +12,4 @@ class HibitBackendRefactorApplicationTests {
     }
 
 }
+*/

--- a/src/test/java/com/hibitbackendrefactor/IntegrationTestSupport.java
+++ b/src/test/java/com/hibitbackendrefactor/IntegrationTestSupport.java
@@ -1,0 +1,13 @@
+package com.hibitbackendrefactor;
+
+import com.hibitbackendrefactor.config.ExternalApiConfig;
+import com.hibitbackendrefactor.global.config.JpaAuditingConfig;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(JpaAuditingConfig.class)
+@ActiveProfiles("test")
+@SpringBootTest(classes = ExternalApiConfig.class)
+public abstract class IntegrationTestSupport {
+}

--- a/src/test/java/com/hibitbackendrefactor/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/application/AuthServiceTest.java
@@ -1,21 +1,19 @@
 package com.hibitbackendrefactor.auth.application;
 
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.auth.domain.TokenRepository;
 import com.hibitbackendrefactor.auth.dto.request.TokenRenewalRequest;
 import com.hibitbackendrefactor.auth.dto.response.AccessAndRefreshTokenResponse;
 import com.hibitbackendrefactor.auth.dto.response.AccessTokenResponse;
 import com.hibitbackendrefactor.auth.event.MemberSavedEvent;
 import com.hibitbackendrefactor.auth.exception.InvalidTokenException;
-import com.hibitbackendrefactor.config.ExternalApiConfig;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
@@ -26,10 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@SpringBootTest(classes = ExternalApiConfig.class)
-@ActiveProfiles("test")
 @RecordApplicationEvents
-class AuthServiceTest {
+class AuthServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private AuthService authService;

--- a/src/test/java/com/hibitbackendrefactor/auth/application/AuthTokenCreatorTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/application/AuthTokenCreatorTest.java
@@ -1,18 +1,14 @@
 package com.hibitbackendrefactor.auth.application;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.auth.domain.AuthToken;
-import com.hibitbackendrefactor.config.ExternalApiConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = ExternalApiConfig.class)
-@ActiveProfiles("test")
-class AuthTokenCreatorTest {
+class AuthTokenCreatorTest extends IntegrationTestSupport {
 
     @Autowired
     private TokenCreator tokenCreator;

--- a/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepositoryTest.java
@@ -1,14 +1,12 @@
 package com.hibitbackendrefactor.auth.domain;
 
-import com.hibitbackendrefactor.global.config.JpaAuditingConfig;
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -16,10 +14,8 @@ import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.OAuthTokenFixtures.REFRESH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@Import(JpaAuditingConfig.class)
-@ActiveProfiles("test")
-class OAuthTokenRepositoryTest {
+@Transactional
+class OAuthTokenRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/hibitbackendrefactor/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/auth/presentation/AuthControllerTest.java
@@ -1,21 +1,11 @@
 package com.hibitbackendrefactor.auth.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hibitbackendrefactor.auth.application.AuthService;
-import com.hibitbackendrefactor.auth.application.OAuthUri;
+import com.hibitbackendrefactor.ControllerTestSupport;
 import com.hibitbackendrefactor.auth.exception.InvalidTokenException;
-import com.hibitbackendrefactor.config.ExternalApiConfig;
 import com.hibitbackendrefactor.infrastructure.oauth.exception.OAuthException;
-import com.hibitbackendrefactor.member.application.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 
 import javax.servlet.http.Cookie;
 
@@ -27,25 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = AuthController.class)
-@Import(ExternalApiConfig.class)
-@ActiveProfiles("test")
-class AuthControllerTest {
-
-    @Autowired
-    protected MockMvc mockMvc;
-
-    @Autowired
-    protected ObjectMapper objectMapper;
-
-    @MockBean
-    protected AuthService authService;
-
-    @MockBean
-    protected OAuthUri oAuthUri;
-
-    @MockBean
-    protected MemberService memberService;
+class AuthControllerTest extends ControllerTestSupport {
 
     @DisplayName("OAuth 소셜 로그인을 위한 링크와 상태코드 200을 반환한다.")
     @Test

--- a/src/test/java/com/hibitbackendrefactor/member/application/MemberServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.member.application;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.auth.domain.OAuthToken;
 import com.hibitbackendrefactor.auth.domain.OAuthTokenRepository;
 import com.hibitbackendrefactor.common.builder.BuilderSupporter;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = ExternalApiConfig.class)
 @ActiveProfiles("test")
-class MemberServiceTest {
+class MemberServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private MemberService memberService;

--- a/src/test/java/com/hibitbackendrefactor/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/member/domain/MemberRepositoryTest.java
@@ -1,19 +1,20 @@
 package com.hibitbackendrefactor.member.domain;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.exception.NotFoundMemberException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시_이메일;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@DataJpaTest
-class MemberRepositoryTest {
+@Transactional
+class MemberRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.post.application;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.post.domain.Post;
@@ -11,8 +12,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
@@ -20,9 +19,8 @@ import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_�
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ActiveProfiles("test")
-@SpringBootTest
-class PostServiceTest {
+class PostServiceTest extends IntegrationTestSupport {
+
     @Autowired
     private PostRepository postRepository;
 

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
@@ -1,12 +1,13 @@
 package com.hibitbackendrefactor.post.domain;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,8 +18,8 @@ import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 @ActiveProfiles("test")
-@DataJpaTest
-class PostRepositoryTest {
+@Transactional
+class PostRepositoryTest extends IntegrationTestSupport {
 
 
     @Autowired

--- a/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
@@ -1,20 +1,14 @@
 package com.hibitbackendrefactor.post.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hibitbackendrefactor.auth.application.AuthService;
+import com.hibitbackendrefactor.ControllerTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
-import com.hibitbackendrefactor.post.application.PostService;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
 import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
 import com.hibitbackendrefactor.post.dto.response.PostResponse;
 import com.hibitbackendrefactor.post.dto.response.PostsResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -31,22 +25,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
-@WebMvcTest(controllers = PostController.class)
-class PostControllerTest {
+class PostControllerTest extends ControllerTestSupport {
     private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
     private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaaaaaa.bbbbbbbb.cccccccc";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private PostService postService;
-
-    @MockBean
-    private AuthService authService;
 
     @DisplayName("게시글을 등록한다.")
     @Test

--- a/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.profile.application;
 
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.profile.domain.*;
@@ -10,8 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
@@ -19,9 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
-@ActiveProfiles("test")
-@SpringBootTest
-class ProfileServiceTest {
+class ProfileServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ProfileService profileService;

--- a/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileRepositoryTest.java
@@ -1,23 +1,19 @@
 package com.hibitbackendrefactor.profile.domain;
 
-import com.hibitbackendrefactor.global.config.JpaAuditingConfig;
+import com.hibitbackendrefactor.IntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@Import(JpaAuditingConfig.class)
-@ActiveProfiles("test")
-class ProfileRepositoryTest {
+@Transactional
+class ProfileRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private ProfileRepository profileRepository;

--- a/src/test/java/com/hibitbackendrefactor/profile/presentation/ProfileControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/presentation/ProfileControllerTest.java
@@ -1,8 +1,6 @@
 package com.hibitbackendrefactor.profile.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hibitbackendrefactor.auth.application.AuthService;
-import com.hibitbackendrefactor.profile.application.ProfileService;
+import com.hibitbackendrefactor.ControllerTestSupport;
 import com.hibitbackendrefactor.profile.domain.AddressCity;
 import com.hibitbackendrefactor.profile.domain.AddressDistrict;
 import com.hibitbackendrefactor.profile.domain.PersonalityType;
@@ -10,34 +8,17 @@ import com.hibitbackendrefactor.profile.dto.request.ProfileCreateRequest;
 import com.hibitbackendrefactor.profile.dto.request.ProfileUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = ProfileController.class)
-class ProfileControllerTest {
+class ProfileControllerTest extends ControllerTestSupport {
 
     private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
     private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaaaaaa.bbbbbbbb.cccccccc";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private ProfileService profileService;
-
-    @MockBean
-    private AuthService authService;
 
     @DisplayName("본인 프로필을 등록한다.")
     @Test

--- a/src/test/resources/application-example.yml
+++ b/src/test/resources/application-example.yml
@@ -7,34 +7,43 @@ spring:
     session:
       cookie:
         http-only: true
-
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:db?serverTimezone=Asia/Seoul;MODE=MYSQL;
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
   jpa:
     open-in-view: true
     hibernate:
       ddl-auto: create
-    show_sql: true
     properties:
-      dialect: org.hibernate.dialect.MySQL8Dialect
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+    show-sql: true
 
   sql:
     init:
       mode: never
+
 logging:
   level:
-    com:
-      amazonaws:
-        util:
-          EC2MetadataUtils: error
-    org.hibernate.SQL: ERROR
+    org:
+      hibernate:
+        type: trace
 
 server:
   compression:
     enabled: true
     mime-types: text/html,text/plain,text/css,application/javascript,application/json
     min-response-size: 500
-
+  session:
+    cookie:
+      http-only: false
 
 # Google OAuth
 cors:


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

Closes #33 

## 결과

> 테스트 환경 통합 이전 - 서버 횟수: 10

<img width="823" alt="테스트환경통합_이전" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/fc65e0ff-1232-4bd0-8a3c-42d6b60c540f">


>  테스트 환경 통합 이후 - 서버 횟수: 2

<img width="827" alt="테스트환경통합_이후" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/311dde02-6ae2-4063-b812-06ac5c647a53">
