### PR TITLE
[CI] 백엔드 코드가 운영 코드의 커버리지 80% 이하라면 빌드를 실패하도록 Jacoco를 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.10'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'jacoco'
 }
 
 group = 'com'
@@ -59,6 +60,77 @@ tasks.named('bootBuildImage') {
     builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    // JaCoCo 버전
+    toolVersion = '0.8.7'
+}
+
+jacocoTestReport {
+    reports {
+        // 원하는 리포트를 켜고 끌 수 있습니다.
+        html.enabled true
+        xml.enabled true
+        csv.enabled true
+
+        //  각 리포트 타입마다 리포트 저장 경로를 설정할 수 있습니다.
+        html.destination file("${buildDir}/jacoco/index.html")
+        xml.destination file("${buildDir}/jacoco/index.xml")
+        csv.destination file("${buildDir}/jacoco/index.csv")
+    }
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/*Application*',
+                            '**/*Exception*',
+                            '**/auth/event/**',
+                            '**/dto/**',
+                            '**/common/**',
+                            '**/global/**',
+                            '**/infrastructure/**',
+                            '**/BaseEntity**',
+                            '**/AuthorizationExtractor*',
+                            '**/AuthenticationPrincipal*'
+                    ])
+                })
+        )
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    // 이 커버리지 기준은 이 글의 맨 아래에서 다시 설명하겠습니다.
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = [
+                    '*.*Application',
+                    '*.*Exception',
+                    '**.auth.event.*',
+                    '*.dto.*',
+                    '*.common.*',
+                    '*.global.*',
+                    '*.infrastructure.*',
+                    '*.global.config.*',
+                    '*.BaseEntity',
+                    '*.ControllerAdvice',
+                    '*.AuthorizationExtractor',
+                    '*.AuthenticationPrincipal.*'
+            ]
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/hibitbackendrefactor/post/domain/Post.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/Post.java
@@ -14,7 +14,7 @@ public class Post extends BaseEntity {
     @Column(name = "post_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostDetailResponse.java
@@ -41,7 +41,7 @@ public class PostDetailResponse {
         this.id = id;
         this.writerId = writerId;
         this.writerName = writerName;
-        this.writerImage = writerImage;
+//        this.writerImage = writerImage;
         this.title = title;
         this.content = content;
         this.exhibition = exhibition;
@@ -57,7 +57,7 @@ public class PostDetailResponse {
                 .id(post.getId())
                 .writerId(post.getMember().getId())
                 .writerName(post.getMember().getDisplayName())
-                .writerImage(findWriterImage(post.getMember()))
+//                .writerImage(findWriterImage(post.getMember()))
                 .title(post.getTitle())
                 .content(post.getContent())
                 .exhibition(post.getExhibition())

--- a/src/main/java/com/hibitbackendrefactor/profile/domain/Profile.java
+++ b/src/main/java/com/hibitbackendrefactor/profile/domain/Profile.java
@@ -22,7 +22,7 @@ public class Profile extends BaseEntity {
     @Column(name = "profile_id", unique = true)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST) // 프로필이 저장될 때, 연관된 Member 엔티티도 함께 저장
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
+++ b/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.common.fixtures;
 
+import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.post.domain.Post;
 import com.hibitbackendrefactor.post.domain.PostStatus;
 import com.hibitbackendrefactor.post.domain.TogetherActivity;
@@ -42,6 +43,21 @@ public class PostFixtures {
     public static final PostStatus 모집상태2 = PostStatus.HOLDING;
 
 
+    public static Post 프로젝트_해시테크(Member member) {
+        return Post.builder()
+                .member(member)
+                .title(게시글제목1)
+                .content(게시글내용1)
+                .exhibition(전시회제목1)
+                .exhibitionAttendance(전시관람인원1)
+                .possibleTime(전시관람희망날짜1)
+                .openChatUrl(오픈채팅방Url1)
+                .togetherActivity(함께하고싶은활동1)
+                .imageName(게시글이미지1)
+                .postStatus(모집상태1)
+                .build();
+    }
+
     public static Post 프로젝트_해시테크() {
         return Post.builder()
                 .member(팬시())
@@ -57,9 +73,9 @@ public class PostFixtures {
                 .build();
     }
 
-    public static Post 오스틴리_전시회() {
+    public static Post 오스틴리_전시회(Member member) {
         return Post.builder()
-                .member(팬시())
+                .member(member)
                 .title(게시글제목2)
                 .content(게시글내용2)
                 .exhibition(전시회제목2)

--- a/src/test/java/com/hibitbackendrefactor/member/application/MemberServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/member/application/MemberServiceTest.java
@@ -38,7 +38,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     private OAuthTokenRepository oAuthTokenRepository;
 
     @AfterEach
-    void setUp() {
+    void tearDown() {
         oAuthTokenRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -33,6 +33,8 @@ class PostServiceTest extends IntegrationTestSupport {
     @Autowired
     private PostService postService;
 
+    private Post post;
+
     @AfterEach
     void tearDown() {
         postRepository.deleteAll();
@@ -40,11 +42,12 @@ class PostServiceTest extends IntegrationTestSupport {
         memberRepository.deleteAll(); // deleteAllInBatch()인 경우 오류는 나중에 해결할 예정(23.01.10)
     }
 
-    @DisplayName("게시글을 등록한다.")
+    @DisplayName("게시글을 등록한 페이지를 반환한다.")
     @Test
-    void 게시글을_등록한다() {
+    void 게시글을_등록한_페이지를_반환한다() {
         // given
         Member 팬시 = 팬시();
+        memberRepository.save(팬시);
         Profile 팬시_프로필 = 팬시_프로필(팬시);
         profileRepository.save(팬시_프로필);
 

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -6,6 +6,7 @@ import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.post.domain.Post;
 import com.hibitbackendrefactor.post.domain.PostRepository;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
+import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
 import com.hibitbackendrefactor.profile.domain.Profile;
 import com.hibitbackendrefactor.profile.domain.ProfileRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +18,7 @@ import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
 import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PostServiceTest extends IntegrationTestSupport {
@@ -32,9 +34,6 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private PostService postService;
-
-    private Post post;
-
     @AfterEach
     void tearDown() {
         postRepository.deleteAll();
@@ -48,9 +47,58 @@ class PostServiceTest extends IntegrationTestSupport {
         // given
         Member 팬시 = 팬시();
         memberRepository.save(팬시);
-        Profile 팬시_프로필 = 팬시_프로필(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile 팬시_프로필 = 팬시_프로필(member);
         profileRepository.save(팬시_프로필);
 
+        // when
+        PostCreateRequest request = getPostCreateRequest();
+        Long newPostId = postService.save(팬시_프로필.getMember().getId(), request);
+        Post savedPost = postRepository.findByMemberId(팬시.getId()).orElse(null);
+
+        // then
+        assertThat(newPostId).isNotNull();
+        assertAll(
+                () -> assertEquals("프로젝트_해시테크", savedPost.getTitle()),
+                () -> assertEquals("프로젝트 해시 태크(http://projecthashtag.net/) 보러가실 분 있으면 아래 댓글 남겨주세요~", savedPost.getContent()),
+                () -> assertEquals("PROJECT HASHTAG 2023 SELECTED ARTISTS", savedPost.getExhibition()),
+                () -> assertEquals(3, savedPost.getExhibitionAttendance()),
+                () -> assertEquals("postImage1.png", savedPost.getImageName())
+        );
+    }
+
+    @DisplayName("게시글에 대한 상세 페이지를 반환한다.")
+    @Test
+    void 게시글에_대한_상세_페이지를_반환한다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile 팬시_프로필 = 팬시_프로필(member);
+        Profile profile =  profileRepository.save(팬시_프로필);
+        memberRepository.save(팬시);
+
+        Post post = 프로젝트_해시테크(profile.getMember());
+        Long savedPostId = postRepository.save(post).getId();
+
+        // when
+        PostDetailResponse response = postService.findPost(savedPostId);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(post.getId()),
+                () -> assertThat(response.getWriterId()).isEqualTo(post.getMember().getId()),
+                () -> assertThat(response.getWriterName()).isEqualTo(post.getMember().getDisplayName()),
+//                () -> assertThat(response.getWriterImage()).isEqualTo(post.getMember().getMainImage()),
+                () -> assertThat(response.getTitle()).isEqualTo(post.getTitle()),
+                () -> assertThat(response.getContent()).isEqualTo(post.getContent()),
+                () -> assertThat(response.getExhibition()).isEqualTo(post.getExhibition())
+        );
+    }
+
+    private static PostCreateRequest getPostCreateRequest() {
         PostCreateRequest request = PostCreateRequest.builder()
                 .title(게시글제목1)
                 .content(게시글내용1)
@@ -62,14 +110,6 @@ class PostServiceTest extends IntegrationTestSupport {
                 .imageName(게시글이미지1)
                 .postStatus(모집상태1)
                 .build();
-
-        // when
-        Long newPostId = postService.save(팬시_프로필.getMember().getId(), request);
-        Post savedPost = postRepository.findByMemberId(팬시.getId()).orElse(null);
-
-        // then
-        assertThat(newPostId).isNotNull();
-        assertEquals("프로젝트_해시테크", savedPost.getTitle());
-
+        return request;
     }
 }

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
@@ -2,67 +2,75 @@ package com.hibitbackendrefactor.post.domain;
 
 import com.hibitbackendrefactor.IntegrationTestSupport;
 import com.hibitbackendrefactor.member.domain.Member;
+import com.hibitbackendrefactor.member.domain.MemberRepository;
+import com.hibitbackendrefactor.profile.domain.Profile;
+import com.hibitbackendrefactor.profile.domain.ProfileRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 
-import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.브루스;
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
-import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static com.hibitbackendrefactor.common.fixtures.PostFixtures.프로젝트_해시테크;
+import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @Transactional
 class PostRepositoryTest extends IntegrationTestSupport {
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
 
     @Autowired
     private PostRepository postRepository;
 
-    @DisplayName("등록된 모든 게시글을 조회한다.")
-    @Test
-    void 등록된_모든_게시글을_조회한다() {
-        // given
-        Post post1 = createPost(팬시(), 게시글제목1, 게시글내용1, 전시회제목1, 전시관람인원1, 전시관람희망날짜1, 오픈채팅방Url1, 함께하고싶은활동1, 게시글이미지1, 모집상태1);
-        Post post2 = createPost(브루스(), 게시글제목2, 게시글내용2, 전시회제목2, 전시관람인원2, 전시관람희망날짜2, 오픈채팅방Url2, 함께하고싶은활동2, 게시글이미지2, 모집상태2);
+    private Member member;
 
-        postRepository.saveAll(List.of(post1, post2));
+    private Profile profile;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        member = 팬시();
+        memberRepository.save(member);
+        profile = 팬시_프로필(member);
+        profileRepository.save(profile);
+        post = 프로젝트_해시테크(member);
+        postRepository.save(post);
+    }
+
+    @DisplayName("게시글과 회원 테이블이 정상적으로 매핑이 된다.")
+    @Test
+    void 게시글과_회원_테이블이_정상적으로_매핑이_된다() {
+        // given
+        Post foundPost = postRepository.getById(post.getId());
+
+        // when & then
+        Assertions.assertThat(foundPost.getMember().getId()).isNotNull();
+    }
+
+    @DisplayName("특정 회원 ID에 해당하는 게시글을 찾는다.")
+    @Test
+    void 특정_회원_ID에_해당하는_게시글을_찾는다() {
+        // given
+        Long memberId = post.getMember().getId();
 
         // when
-        List<Post> posts = postRepository.findAllByOrderByCreatedDateTimeDesc();
+        Optional<Post> actual = postRepository.findByMemberId(memberId);
 
         // then
-        Assertions.assertThat(posts).hasSize(2)
-                .extracting("title", "content", "openChatUrl")
-                .containsExactlyInAnyOrder(
-                        tuple("프로젝트_해시테크", "프로젝트 해시 태크(http://projecthashtag.net/) 보러가실 분 있으면 아래 댓글 남겨주세요~", "http://projecthashtag.net/"),
-                        tuple("오스틴리 전시회", "오스틴리 전시회 보고, 같이 담소하게 얘기 나누실 분 있으시면 아래 댓글 남겨주세요~", "http://ostin.net/")
-                );
-     }
-
-
-     private Post createPost(Member member, String title, String content,
-                             String exhibition, int exhibitionAttendance, LocalDateTime postPossibleTime,
-                             String openChatUrl, TogetherActivity togetherActivity, String imageName, PostStatus postStatus) {
-
-        Post post1 = Post.builder()
-                .member(member)
-                .title(title)
-                .content(content)
-                .exhibition(exhibition)
-                .exhibitionAttendance(exhibitionAttendance)
-                .possibleTime(postPossibleTime)
-                .openChatUrl(openChatUrl)
-                .togetherActivity(togetherActivity)
-                .imageName(imageName)
-                .postStatus(postStatus)
-                .build();
-        return post1;
-     }
+        assertThat(actual).isPresent();
+        Post foundPost = actual.get();
+        assertThat(foundPost.getMember().getId()).isEqualTo(memberId);
+    }
 }

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostTest.java
@@ -1,6 +1,10 @@
 package com.hibitbackendrefactor.post.domain;
 
-import com.hibitbackendrefactor.post.exception.*;
+import com.hibitbackendrefactor.member.domain.Member;
+import com.hibitbackendrefactor.post.exception.InvalidContentException;
+import com.hibitbackendrefactor.post.exception.InvalidExhibitionException;
+import com.hibitbackendrefactor.post.exception.InvalidTitleException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,11 +17,26 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class PostTest {
 
-    @DisplayName("게시글을 등록한다.")
+    @DisplayName("게시글을 등록한다. - Cass1 ")
     @Test
-    void 게시글을_등록한다() {
-        // given & when & then
-        assertDoesNotThrow(() -> 프로젝트_해시테크());
+    void 게시글을_등록한다_Case1() {
+        // when & then
+        Member 팬시 = 팬시();
+
+        // when & then
+        assertDoesNotThrow(() -> 프로젝트_해시테크(팬시));
+    }
+
+    @DisplayName("게시글을 등록한다. - Case 2")
+    @Test
+    void 게시글을_등록한다_Case2() {
+        // when & then
+        Member 팬시 = 팬시();
+
+        // when & then
+        assertDoesNotThrow(() -> new Post(팬시, 게시글제목1, 게시글내용1
+                , 전시회제목1, 전시관람인원1, 전시관람희망날짜1, 오픈채팅방Url1
+                , 함께하고싶은활동1, 게시글이미지1, 모집상태1));
     }
 
     @DisplayName("게시글 제목이 null 이거나 공백인 경우 예외를 던진다.")
@@ -79,4 +98,40 @@ class PostTest {
                 .isInstanceOf(InvalidExhibitionException.class);
 
     }
+
+    @DisplayName("게시글을 작성한 회원 정보를 가져온다.")
+    @Test
+    void 게시글을_작성한_회원_정보를_가져온다() {
+        // given
+        Member 팬시 = 팬시();
+        Post post = 오스틴리_전시회(팬시);
+
+        // when
+        Member foundMember = post.getMember();
+
+        // then
+        Assertions.assertThat(foundMember).isEqualTo(팬시);
+     }
+
+     @DisplayName("게시글의 일부 정보를 가져온다.")
+     @Test
+     void 게시글의_일부_정보를_가져온다() {
+         // given
+         Member 팬시 = 팬시();
+         Post post = 오스틴리_전시회(팬시);
+
+         // when
+         String title = post.getTitle();
+         String content = post.getContent();
+         String exhibition = post.getExhibition();
+         int exhibitionAttendance =  post.getExhibitionAttendance();
+         TogetherActivity togetherActivity = post.getTogetherActivity();
+
+         // then
+         Assertions.assertThat(title).isEqualTo(post.getTitle());
+         Assertions.assertThat(content).isEqualTo(post.getContent());
+         Assertions.assertThat(exhibition).isEqualTo(post.getExhibition());
+         Assertions.assertThat(exhibitionAttendance).isEqualTo(post.getExhibitionAttendance());
+         Assertions.assertThat(togetherActivity).isEqualTo(post.getTogetherActivity());
+      }
 }

--- a/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
@@ -29,9 +29,9 @@ class PostControllerTest extends ControllerTestSupport {
     private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
     private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaaaaaa.bbbbbbbb.cccccccc";
 
-    @DisplayName("게시글을 등록한다.")
+    @DisplayName("신규 게시글을 등록한다.")
     @Test
-    void 게시글을_등록한다() throws Exception {
+    void 신규_게시글을_등록한다() throws Exception {
         // given
         PostCreateRequest request = PostCreateRequest.builder()
                 .title(게시글제목1)

--- a/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
@@ -5,6 +5,8 @@ import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.profile.domain.*;
 import com.hibitbackendrefactor.profile.dto.request.ProfileCreateRequest;
+import com.hibitbackendrefactor.profile.dto.request.ProfileUpdateRequest;
+import com.hibitbackendrefactor.profile.dto.response.ProfileOtherResponse;
 import com.hibitbackendrefactor.profile.dto.response.ProfileResponse;
 import com.hibitbackendrefactor.profile.exception.NotFoundProfileException;
 import org.junit.jupiter.api.AfterEach;
@@ -41,6 +43,7 @@ class ProfileServiceTest extends IntegrationTestSupport {
         // given
         Member 팬시 = 팬시();
         memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
 
         ProfileCreateRequest request = ProfileCreateRequest.builder()
                 .nickname("devFancy")
@@ -58,7 +61,7 @@ class ProfileServiceTest extends IntegrationTestSupport {
                 .build();
 
         // when
-        Long newProfileId = profileService.save(팬시.getId(), request);
+        Long newProfileId = profileService.save(member.getId(), request);
         Profile savedProfile = profileRepository.findByMemberId(팬시.getId()).orElse(null);
 
         // then
@@ -73,7 +76,9 @@ class ProfileServiceTest extends IntegrationTestSupport {
         // given
         Member 팬시 = 팬시();
         memberRepository.save(팬시);
-        Profile profile = 팬시_프로필();
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile profile = 팬시_프로필(member);
         Long memberId = profileRepository.save(profile).getMember().getId();
 
         // when
@@ -101,4 +106,66 @@ class ProfileServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> profileService.findMyProfile(잘못된_아이디))
                 .isInstanceOf(NotFoundProfileException.class);
     }
+
+    @DisplayName("본인의 프로필을 수정한다.")
+    @Test
+    void 본인의_프로필을_수정한다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile profile = 팬시_프로필(member);
+        Long memberId = profileRepository.save(profile).getMember().getId();
+
+        // when
+        ProfileUpdateRequest request = ProfileUpdateRequest.builder()
+                .nickname("devFancy2")
+                .age(29)
+                .gender(1)
+                .personality(PersonalityType.TYPE_1)
+                .introduce("안녕하세요 서버 개발자로 살아가는 팬시입니다.")
+                .imageName("image2.png")
+                .job("서버 개발자")
+                .addressCity(AddressCity.SEOUL)
+                .addressDistrict(AddressDistrict.SEOUL_GANGNAM)
+                .jobVisibility(true)
+                .addressVisibility(false)
+                .myImageVisibility(false)
+                .build();
+
+        profileService.update(memberId, request);
+        Profile updatedProfile = profileRepository.findByMemberId(팬시.getId()).orElse(null);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedProfile.getNickname()).isEqualTo(request.getNickname()),
+                () -> assertThat(updatedProfile.getAge()).isEqualTo(request.getAge()),
+                () -> assertThat(updatedProfile.getGender()).isEqualTo(request.getGender()),
+                () -> assertThat(updatedProfile.getPersonality()).isEqualTo(request.getPersonality()),
+                () -> assertThat(updatedProfile.getIntroduce()).isEqualTo(request.getIntroduce()),
+                () -> assertThat(updatedProfile.getImageName()).isEqualTo(request.getImageName()),
+                () -> assertThat(updatedProfile.getJob()).isEqualTo(request.getJob()),
+                () -> assertThat(updatedProfile.getAddressCity()).isEqualTo(request.getAddressCity()),
+                () -> assertThat(updatedProfile.getAddressDistrict()).isEqualTo(request.getAddressDistrict())
+        );
+    }
+
+    @DisplayName("타인의 프로필 정보를 조회한다.")
+    @Test
+    void 타인의_프로필_정보를_조회한다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile profile = 팬시_프로필(member);
+        Long memberId = profileRepository.save(profile).getMember().getId();
+
+        // when
+        ProfileOtherResponse response = profileService.findOtherProfile(memberId);
+
+        // then
+        assertNotNull(response);
+     }
 }

--- a/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.hibitbackendrefactor.profile.domain;
 
 import com.hibitbackendrefactor.IntegrationTestSupport;
+import com.hibitbackendrefactor.member.domain.Member;
+import com.hibitbackendrefactor.member.domain.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,11 +21,18 @@ class ProfileRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private ProfileRepository profileRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     private Profile profile1;
+
+    private Member member1;
 
     @BeforeEach
     void setUp() {
-        profile1 = 팬시_프로필();
+        member1 = 팬시();
+        memberRepository.save(member1);
+        profile1 = 팬시_프로필(member1);
         profileRepository.save(profile1);
     }
 

--- a/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/domain/ProfileTest.java
@@ -3,6 +3,7 @@ package com.hibitbackendrefactor.profile.domain;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.profile.exception.InvalidIntroduceException;
 import com.hibitbackendrefactor.profile.exception.InvalidNicknameException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -108,5 +109,101 @@ class ProfileTest {
         ).isInstanceOf(InvalidIntroduceException.class);
     }
 
+    @DisplayName("본인의 프로필에서 나이를 변경한다.")
+    @Test
+    void 본인의_프로필에서_나이를_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        int age = 29;
 
+        // when
+        profile.updateAge(age);
+
+        // then
+        Assertions.assertThat(profile.getAge()).isEqualTo(age);
+     }
+
+    @DisplayName("본인의 프로필에서 자기소개를 변경한다.")
+    @Test
+    void 본인의_프로필에서_자기소개를_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        String introduce = "안녕하세요 서버 개발자로 살아가는 팬시입니다.";
+
+        // when
+        profile.updateIntroduce(introduce);
+
+        // then
+        Assertions.assertThat(profile.getIntroduce()).isEqualTo(introduce);
+    }
+
+    @DisplayName("본인의 프로필에서 성격을 변경한다.")
+    @Test
+    void 본인의_프로필에서_성격을_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        PersonalityType personalityType = PersonalityType.TYPE_2;
+
+        // when
+        profile.updatePersonality(personalityType);
+
+        // then
+        Assertions.assertThat(profile.getPersonality()).isEqualTo(personalityType);
+    }
+
+    @DisplayName("본인의 프로필에서 이미지를 변경한다.")
+    @Test
+    void 본인의_프로필에서_이미지를_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        String imageName = "devfancy.png";
+
+        // when
+        profile.updateImageName(imageName);
+
+        // then
+        Assertions.assertThat(profile.getImageName()).isEqualTo(imageName);
+    }
+
+    @DisplayName("본인의 프로필에서 직업을 변경한다.")
+    @Test
+    void 본인의_프로필에서_직업을_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        String job = "서버 개발자";
+
+        // when
+        profile.updateJob(job);
+
+        // then
+        Assertions.assertThat(profile.getJob()).isEqualTo(job);
+    }
+
+    @DisplayName("본인의 프로필에서 주소인 도시를 변경한다.")
+    @Test
+    void 본인의_프로필에서_주소인_도시를_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        AddressCity addressCity = AddressCity.BUSAN;
+
+        // when
+        profile.updateAddressCity(addressCity);
+
+        // then
+        Assertions.assertThat(profile.getAddressCity()).isEqualTo(addressCity);
+    }
+
+    @DisplayName("본인의 프로필에서 주소인 구를 변경한다.")
+    @Test
+    void 본인의_프로필에서_주소인_구를_변경한다() {
+        // given
+        Profile profile = 팬시_프로필();
+        AddressDistrict addressDistrict = AddressDistrict.BUSAN_HAEUNDAE;
+
+        // when
+        profile.updateAddressDistinct(addressDistrict);
+
+        // then
+        Assertions.assertThat(profile.getAddressDistrict()).isEqualTo(addressDistrict);
+    }
 }


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

Closes #35 

##  결과

> 테스트 커버리지 80% 달성

<img width="1000" alt="테스트_커버리지_결과" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/af79c580-87c5-40a7-b531-2e6010149dc2">
b-00e3-4e65-b343-04f88e72de20">

> 현재 테스트 코드 갯수: 155개

<img width="900" alt="240119_테스트_갯수" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/ff7331f4-f0fe-4b64-9360-5b30b0b55fd6">



