### PR TITLE
특정 게시글에 대한 조회 성능을 개선한다.

### DIFF
--- a/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
+++ b/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
@@ -91,7 +91,7 @@ public class PostService {
     }
 
     private Post findPostObject(final Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findPostById(postId)
                 .orElseThrow(NotFoundPostException::new);
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.post.domain;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
     void updateViewCount(@Param("postId") Long postId);
+
+    @EntityGraph(attributePaths = "member")
+    Optional<Post> findPostById(Long id);
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -28,5 +28,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     void updateViewCount(@Param("postId") Long postId);
 
     @EntityGraph(attributePaths = "member")
+    @Query("SELECT p FROM Post p")
     Optional<Post> findPostById(Long id);
 }


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

Closes #43 

## 전/후 비교

성능 테스트 도구: JMeter

동시 사용자 100명이 1초동안 10번 반복(총 1000번)했을 때 TPS

> 쿼리 작성 전 - 평균 TPS : 27.9 / 최대 TPS: 30

<img width="1000" alt="쿼리-적용-전-요약보고서" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/b72ded7b-574e-45e4-bda6-83dc7af727fe">

<img width="1001" alt="쿼리-적용-전-jp@gc-Transactions-per-Second" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/3492c351-8338-4ae1-843c-74f03be6f02e">


> 쿼리 작성 후 - 평균 TPS: 39.1 / 최대 TPS: 42

<img width="1000" alt="쿼리-적용-전-요약보고서" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/61003e98-2e21-4477-95b0-6f7d7e4cc502">

<img width="1000" alt="쿼리-적용-후-jp@gc-Transactions-per-Second" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/19a54342-3876-415b-b826-dd78b4dc2859">
