### PR TITLE
데이터베이스 다중화 적용

### DIFF
--- a/src/main/java/com/hibitbackendrefactor/global/config/replication/DataSourceConfiguration.java
+++ b/src/main/java/com/hibitbackendrefactor/global/config/replication/DataSourceConfiguration.java
@@ -1,0 +1,60 @@
+package com.hibitbackendrefactor.global.config.replication;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@Configuration
+@Profile("prod")
+public class DataSourceConfiguration {
+    private static final String SOURCE_NAME = "SOURCE";
+    private static final String REPLICA_NAME = "REPLICA";
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        DataSource determinedDataSource = routingDataSource(sourceDataSource(), replicaDataSource());
+        return new LazyConnectionDataSourceProxy(determinedDataSource);
+    }
+
+    @Bean
+    @Qualifier(SOURCE_NAME)
+    @ConfigurationProperties(prefix = "spring.datasource.source")
+    public DataSource sourceDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean
+    @Qualifier(REPLICA_NAME)
+    @ConfigurationProperties(prefix = "spring.datasource.replica")
+    public DataSource replicaDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(SOURCE_NAME) DataSource sourceDataSource,
+            @Qualifier(REPLICA_NAME) DataSource replicaDataSource
+    ) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        HashMap<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("source", sourceDataSource);
+        dataSourceMap.put("replica", replicaDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(sourceDataSource);
+
+        return routingDataSource;
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/global/config/replication/DataSourceKey.java
+++ b/src/main/java/com/hibitbackendrefactor/global/config/replication/DataSourceKey.java
@@ -1,0 +1,33 @@
+package com.hibitbackendrefactor.global.config.replication;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum DataSourceKey {
+    SOURCE(KeyName.SOURCE_NAME, false),
+    REPLICA_1(KeyName.REPLICA_1_NAME, true),
+    REPLICA_2(KeyName.REPLICA_2_NAME, true);
+
+
+    private final String key;
+    private final boolean isReplica;
+
+    DataSourceKey(final String key, final boolean isReplica) {
+        this.key = key;
+        this.isReplica = isReplica;
+    }
+
+    public static List<DataSourceKey> getReplicas() {
+        return Arrays.stream(values())
+                .filter(key -> key.isReplica)
+                .collect(Collectors.toList());
+    }
+
+    // 다른 클래스에서 어노테이션으로 참조될 수 있도록 중첩 클래스에 상수 선언
+    public static class KeyName {
+        public static final String SOURCE_NAME = "SOURCE";
+        public static final String REPLICA_1_NAME = "REPLICA_1";
+        public static final String REPLICA_2_NAME = "REPLICA_2";
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/global/config/replication/RandomReplicaKeys.java
+++ b/src/main/java/com/hibitbackendrefactor/global/config/replication/RandomReplicaKeys.java
@@ -1,0 +1,21 @@
+package com.hibitbackendrefactor.global.config.replication;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class RandomReplicaKeys {
+    private static final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    private final List<DataSourceKey> dataSourceKeys;
+
+    private final int size;
+
+    public RandomReplicaKeys() {
+        this.dataSourceKeys = List.copyOf(DataSourceKey.getReplicas());
+        this.size = dataSourceKeys.size();
+    }
+    public DataSourceKey next() {
+        int currentDataSourceIndex = random.nextInt(size);
+        return dataSourceKeys.get(currentDataSourceIndex);
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/global/config/replication/RoutingDataSource.java
+++ b/src/main/java/com/hibitbackendrefactor/global/config/replication/RoutingDataSource.java
@@ -3,8 +3,11 @@ package com.hibitbackendrefactor.global.config.replication;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import static com.hibitbackendrefactor.global.config.replication.DataSourceKey.SOURCE;
+
 public class RoutingDataSource extends AbstractRoutingDataSource {
 
+    private final RandomReplicaKeys randomReplicaKeys = new RandomReplicaKeys();
     @Override
     protected Object determineCurrentLookupKey() {
         boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
@@ -13,9 +16,9 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
 
         if(isReadOnly) {
             System.out.println("Replica 서버로 요청합니다.");
-            return "replica";
+            return randomReplicaKeys.next();
         }
         System.out.println("Source 서버로 요청합니다.");
-        return "source";
+        return SOURCE;
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/global/config/replication/RoutingDataSource.java
+++ b/src/main/java/com/hibitbackendrefactor/global/config/replication/RoutingDataSource.java
@@ -1,0 +1,21 @@
+package com.hibitbackendrefactor.global.config.replication;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        System.out.println("Transaction의 Read Only가 " + isReadOnly + " 입니다.");
+
+        if(isReadOnly) {
+            System.out.println("Replica 서버로 요청합니다.");
+            return "replica";
+        }
+        System.out.println("Source 서버로 요청합니다.");
+        return "source";
+    }
+}


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

데이터베이스 레플리케이션을 적용했습니다.

Closes #49 

### 인프라

기존 Dev용 EC2 서버에 RDS(Source)에서 Replica1, Replica2 를 추가로 구축했습니다.

## 성능 테스트 결과

### 쓰기 작업

> 게시글 전체 조회 (사진을 클릭하면 크케 볼 수 있습니다)

동시 접속 사용자 100명을 기준으로 1초 동안 20번 반복 (총 2000명)으로 가정하고 테스트했습니다.

#### 레플리케이션 적용 전

1. 요약 보고서

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/35c393ad-ba77-457f-a4c6-c44e0861af4d)

2. Transactional per Second

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/ef52eeb7-3af7-4d1f-bade-05d1604f6394)

#### 레플리케이션 적용 후

1. 요약 보고서

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/478b1ebf-2563-4317-832d-771f1f615359)

2. Transactional per Second

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/4a87a9c4-163f-4810-af44-3dbcc3056a11)

#### 정리

총 처리 시간은 기존 50초에서 12초로 단축했고, 처리량(throughput)은 약 4.4배 증가했습니다.