### PR TITLE
게시글에 대한 검색 기능 구현

### DIFF
--- a/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
+++ b/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
@@ -16,6 +16,7 @@ import com.hibitbackendrefactor.profile.exception.NotFoundProfileException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -114,7 +115,7 @@ public class PostService {
         pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), DESC, "created_date_time");
         SearchQuery searchQuery = new SearchQuery(query);
 
-        Page<Post> posts = postRepository.findPostSlicePageByQuery(pageable, searchQuery.getValue());
+        Slice<Post> posts = postRepository.findPostSlicePageByQuery(pageable, searchQuery.getValue());
         return PostsSliceResponse.ofPostSlice(posts);
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
+++ b/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
@@ -109,4 +109,12 @@ public class PostService {
         Page<Post> posts = postRepository.findPostPagesByQuery(pageable, searchQuery.getValue());
         return PostsCountResponse.of((int) posts.getTotalElements());
     }
+
+    public PostsSliceResponse searchSlickWithQuery(final String query, Pageable pageable) {
+        pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), DESC, "created_date_time");
+        SearchQuery searchQuery = new SearchQuery(query);
+
+        Page<Post> posts = postRepository.findPostSlicePageByQuery(pageable, searchQuery.getValue());
+        return PostsSliceResponse.ofPostSlice(posts);
+    }
 }

--- a/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
+++ b/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
@@ -3,21 +3,25 @@ package com.hibitbackendrefactor.post.application;
 import com.hibitbackendrefactor.auth.dto.LoginMember;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
-import com.hibitbackendrefactor.post.domain.Post;
-import com.hibitbackendrefactor.post.domain.PostRepository;
-import com.hibitbackendrefactor.post.domain.PostStatus;
-import com.hibitbackendrefactor.post.domain.ViewCountManager;
+import com.hibitbackendrefactor.post.domain.*;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
 import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsCountResponse;
 import com.hibitbackendrefactor.post.dto.response.PostsResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsSliceResponse;
 import com.hibitbackendrefactor.post.exception.NotFoundPostException;
 import com.hibitbackendrefactor.profile.domain.Profile;
 import com.hibitbackendrefactor.profile.domain.ProfileRepository;
 import com.hibitbackendrefactor.profile.exception.NotFoundProfileException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Service
 @Transactional(readOnly = true)
@@ -96,5 +100,13 @@ public class PostService {
             throw new NotFoundPostException();
         }
         return posts.get(0);
+    }
+
+    public PostsCountResponse countPostWithQuery(final String query) {
+        Pageable pageable = PageRequest.of(0, 3, DESC, "created_date_time");
+        SearchQuery searchQuery = new SearchQuery(query);
+
+        Page<Post> posts = postRepository.findPostPagesByQuery(pageable, searchQuery.getValue());
+        return PostsCountResponse.of((int) posts.getTotalElements());
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -1,5 +1,6 @@
 package com.hibitbackendrefactor.post.domain;
 
+import com.hibitbackendrefactor.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -25,11 +25,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "FROM posts p " +
             "ORDER BY p.created_date_time DESC", nativeQuery = true)
     List<Post> findAllByOrderByCreatedDateTimeDesc();
-
-    @Query("SELECT p "
-            + "FROM Post p "
-            + "WHERE p.member.id = :memberId")
-    Optional<Post> findByMemberId(@Param("memberId") final Long memberId);
 
     @Transactional
     @Modifying

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -42,4 +42,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query(value = SEARCH_SQL, nativeQuery = true)
     Page<Post> findPostPagesByQuery(Pageable pageable, @Param("query") String query);
+
+    @Query(value = SEARCH_SQL, nativeQuery = true)
+    Page<Post> findPostSlicePageByQuery(Pageable pageable, @Param("query") String query);
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -1,8 +1,8 @@
 package com.hibitbackendrefactor.post.domain;
 
-import com.hibitbackendrefactor.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -39,5 +39,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findPostPagesByQuery(Pageable pageable, @Param("query") String query);
 
     @Query(value = SEARCH_SQL, nativeQuery = true)
-    Page<Post> findPostSlicePageByQuery(Pageable pageable, @Param("query") String query);
+    Slice<Post> findPostSlicePageByQuery(Pageable pageable, @Param("query") String query);
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/PostRepository.java
@@ -1,5 +1,7 @@
 package com.hibitbackendrefactor.post.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,6 +13,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    String SEARCH_SQL = "select * from posts where "
+            + "(:query is null or :query = '') "
+            + "or "
+            + "(title regexp :query) "
+            + "or "
+            + "(content regexp :query) ";
 
     @Query(value = "SELECT * " +
             "FROM posts p " +
@@ -30,4 +39,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = "member")
     @Query("SELECT p FROM Post p WHERE p.id = :postId")
     List<Post> findPostById(@Param("postId") final Long postId);
+
+    @Query(value = SEARCH_SQL, nativeQuery = true)
+    Page<Post> findPostPagesByQuery(Pageable pageable, @Param("query") String query);
 }

--- a/src/main/java/com/hibitbackendrefactor/post/domain/SearchQuery.java
+++ b/src/main/java/com/hibitbackendrefactor/post/domain/SearchQuery.java
@@ -1,0 +1,41 @@
+package com.hibitbackendrefactor.post.domain;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class SearchQuery {
+    private static final Pattern SPECIAL_CHARS = Pattern.compile("\\[‘”-#@;=*/+]");
+    private static final Set<String> STRING_SET = Set.of("update", "select", "delete", "insert");
+
+
+    private final String value;
+
+    public SearchQuery(final String value) {
+        this.value = toSafeQuery(value);
+    }
+
+    private String toSafeQuery(String query) {
+        if (query != null) {
+            query = changeNoSqlInjection(query.toLowerCase(Locale.ROOT));
+        }
+        if (query == null) {
+            query = "";
+        }
+        return query;
+    }
+
+    private String changeNoSqlInjection(String query) {
+        query = SPECIAL_CHARS.matcher(query).replaceAll("");
+        for (String s : STRING_SET) {
+            if (query.contains(s)) {
+                return "";
+            }
+        }
+        return query;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostResponse.java
@@ -37,7 +37,7 @@ public class PostResponse {
         this.createDateTime = createDateTime;
     }
 
-    public static PostResponse of(final Post post) {
+    public static PostResponse from(final Post post) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsCountResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsCountResponse.java
@@ -1,0 +1,20 @@
+package com.hibitbackendrefactor.post.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PostsCountResponse {
+    private int totalPostCount;
+
+    protected PostsCountResponse() {
+    }
+
+    public PostsCountResponse(final int totalPostCount) {
+        this.totalPostCount = totalPostCount;
+    }
+
+
+    public static PostsCountResponse of(int totalElements) {
+        return new PostsCountResponse(totalElements);
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsResponse.java
@@ -10,13 +10,13 @@ import java.util.stream.Collectors;
 public class PostsResponse {
     private final List<PostResponse> posts;
 
-    public PostsResponse(List<PostResponse> posts) {
+    public PostsResponse(final List<PostResponse> posts) {
         this.posts = posts;
     }
 
     public static PostsResponse of(final List<Post> posts) {
         List<PostResponse> postResponses = posts.stream()
-                .map(post ->  PostResponse.of(post))
+                .map(post ->  PostResponse.from(post))
                 .collect(Collectors.toList());
         return new PostsResponse(postResponses);
     }

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsSliceResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsSliceResponse.java
@@ -2,7 +2,7 @@ package com.hibitbackendrefactor.post.dto.response;
 
 import com.hibitbackendrefactor.post.domain.Post;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +17,7 @@ public class PostsSliceResponse {
         this.lastPage = lastPage;
     }
 
-    public static PostsSliceResponse ofPostSlice(final Page<Post> postSlice) {
+    public static PostsSliceResponse ofPostSlice(final Slice<Post> postSlice) {
         List<PostResponse> postResponses = postSlice.getContent()
                 .stream()
                 .map(post ->  PostResponse.from(post))

--- a/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsSliceResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/post/dto/response/PostsSliceResponse.java
@@ -1,0 +1,27 @@
+package com.hibitbackendrefactor.post.dto.response;
+
+import com.hibitbackendrefactor.post.domain.Post;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class PostsSliceResponse {
+    private final List<PostResponse> posts;
+    private final boolean lastPage;
+
+    public PostsSliceResponse(final List<PostResponse> posts, final boolean lastPage) {
+        this.posts = posts;
+        this.lastPage = lastPage;
+    }
+
+    public static PostsSliceResponse ofPostSlice(final Page<Post> postSlice) {
+        List<PostResponse> postResponses = postSlice.getContent()
+                .stream()
+                .map(post ->  PostResponse.from(post))
+                .collect(Collectors.toList());
+        return new PostsSliceResponse(postResponses, postSlice.isLast());
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
+++ b/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
@@ -6,17 +6,24 @@ import com.hibitbackendrefactor.post.application.PostService;
 import com.hibitbackendrefactor.post.domain.Post;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
 import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsCountResponse;
 import com.hibitbackendrefactor.post.dto.response.PostsResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsSliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Tag(name = "posts", description = "매칭 게시글")
 @RestController
@@ -28,7 +35,7 @@ public class PostController {
         this.postService = postService;
     }
 
-    @PostMapping("/api/posts/new")
+    @PostMapping(path = "/api/posts/new")
     @Operation(summary = "/api/posts/new", description = "게시글을 등록한다.")
     public ResponseEntity<Post> save(@Parameter(hidden = true)
                                      @AuthenticationPrincipal final LoginMember loginMember
@@ -37,14 +44,14 @@ public class PostController {
         return ResponseEntity.created(URI.create("/posts/" + postId)).build();
     }
 
-    @GetMapping("api/posts")
+    @GetMapping(path = "/api/posts")
     @Operation(summary = "/api/posts", description = "등록된 게시글을 모두 조회한다.")
     public ResponseEntity<PostsResponse> findPosts() {
         PostsResponse responses = postService.findPosts();
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("api/posts/{id}")
+    @GetMapping(path = "/api/posts/{id}")
     @Operation(summary = "/api/posts/{id}", description = "게시글에 대한 상세 페이지를 조회한다.")
     public ResponseEntity<PostDetailResponse> findPost(@PathVariable(name = "id") final Long postId,
                                                        @AuthenticationPrincipal final LoginMember loginMember,
@@ -61,4 +68,13 @@ public class PostController {
         PostsCountResponse postsCountResponse = postService.countPostWithQuery(query);
         return ResponseEntity.ok(postsCountResponse);
     }
+
+    @GetMapping(path = "/api/posts/search")
+    @Operation(summary = "/api/posts/search", description = "특정 값을 입력하여 검색하면 해당 값(제목/내용)이 포함된 게시글을 조회한다.")
+    public ResponseEntity<PostsSliceResponse> searchSlicePosts(@RequestParam @Nullable String query,
+                                                          @PageableDefault(sort = "created_date_time", direction = DESC) Pageable pageable) {
+        PostsSliceResponse postsSliceResponse = postService.searchSlickWithQuery(query, pageable);
+        return ResponseEntity.ok(postsSliceResponse);
+    }
+
 }

--- a/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
+++ b/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
@@ -55,4 +55,10 @@ public class PostController {
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(response);
     }
 
+    @GetMapping(path = "/api/posts/count")
+    @Operation(summary = "/api/posts/count", description = "특정 제목 또는 내용에 해당하는 값을 입력하면 해당 값이 포함된 게시글의 총 개수를 반환한다.")
+    public ResponseEntity<PostsCountResponse> searchPostCount(@RequestParam @Nullable String query) {
+        PostsCountResponse postsCountResponse = postService.countPostWithQuery(query);
+        return ResponseEntity.ok(postsCountResponse);
+    }
 }

--- a/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
+++ b/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
@@ -25,6 +25,20 @@ public class PostFixtures {
     public static final String 게시글이미지1 = "postImage1.png";
     public static final PostStatus 모집상태1 = PostStatus.HOLDING;
 
+    /* 게시글1-2 : 해시태크-2 */
+    public static final String 게시글제목1_2 = "프로젝트_해시테크";
+    public static final String 게시글내용1_2 = "프로젝트 해시 태크(http://projecthashtag.net/) 보러가실 분 있으면 아래 댓글 남겨주세요~";
+
+    public static final String 전시회제목1_2 = "PROJECT HASHTAG 2023 SELECTED ARTISTS";
+
+    public static final int 전시관람인원1_2 = 3;
+    public static final LocalDateTime 전시관람희망날짜1_2 = LocalDateTime.now();
+    public static final String 오픈채팅방Url1_2 = "http://projecthashtag.net/";
+    public static final TogetherActivity 함께하고싶은활동1_2 = TogetherActivity.EAT;
+
+    public static final String 게시글이미지1_2 = "postImage1.png";
+    public static final PostStatus 모집상태1_2 = PostStatus.HOLDING;
+
 
     /* 게시글2: 오스틴리 전시회 */
     public static final String 게시글제목2 = "오스틴리 전시회";
@@ -42,6 +56,20 @@ public class PostFixtures {
 
     public static final PostStatus 모집상태2 = PostStatus.HOLDING;
 
+    public static Post 프로젝트_해시테크_2(Member member) {
+        return Post.builder()
+                .member(member)
+                .title(게시글제목1_2)
+                .content(게시글내용1_2)
+                .exhibition(전시회제목1_2)
+                .exhibitionAttendance(전시관람인원1_2)
+                .possibleTime(전시관람희망날짜1_2)
+                .openChatUrl(오픈채팅방Url1_2)
+                .togetherActivity(함께하고싶은활동1_2)
+                .imageName(게시글이미지1_2)
+                .postStatus(모집상태1_2)
+                .build();
+    }
 
     public static Post 프로젝트_해시테크(Member member) {
         return Post.builder()

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -73,20 +73,20 @@ class PostServiceTest extends IntegrationTestSupport {
         // when
         PostCreateRequest request = getPostCreateRequest();
         Long newPostId = postService.save(팬시_프로필.getMember().getId(), request);
-        Post savedPost = postRepository.findByMemberId(팬시.getId()).orElse(null);
+        Post actual = postRepository.findById(newPostId).orElseThrow();
 
         // then
         assertThat(newPostId).isNotNull();
         assertAll(
-                () -> assertEquals(게시글제목1, savedPost.getTitle()),
-                () -> assertEquals(게시글내용1, savedPost.getContent()),
-                () -> assertEquals(전시회제목1, savedPost.getExhibition()),
-                () -> assertEquals(전시관람인원1, savedPost.getExhibitionAttendance()),
-                () -> assertEquals(전시관람희망날짜1, savedPost.getPossibleTime()),
-                () -> assertEquals(오픈채팅방Url1, savedPost.getOpenChatUrl()),
-                () -> assertEquals(함께하고싶은활동1, savedPost.getTogetherActivity()),
-                () -> assertEquals(전시관람인원1, savedPost.getExhibitionAttendance()),
-                () -> assertEquals(게시글이미지1, savedPost.getImageName())
+                () -> assertEquals(게시글제목1, actual.getTitle()),
+                () -> assertEquals(게시글내용1, actual.getContent()),
+                () -> assertEquals(전시회제목1, actual.getExhibition()),
+                () -> assertEquals(전시관람인원1, actual.getExhibitionAttendance()),
+                () -> assertEquals(전시관람희망날짜1, actual.getPossibleTime()),
+                () -> assertEquals(오픈채팅방Url1, actual.getOpenChatUrl()),
+                () -> assertEquals(함께하고싶은활동1, actual.getTogetherActivity()),
+                () -> assertEquals(전시관람인원1, actual.getExhibitionAttendance()),
+                () -> assertEquals(게시글이미지1, actual.getImageName())
         );
     }
 

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -7,6 +7,9 @@ import com.hibitbackendrefactor.post.domain.Post;
 import com.hibitbackendrefactor.post.domain.PostRepository;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
 import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
+import com.hibitbackendrefactor.post.dto.response.PostResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsCountResponse;
+import com.hibitbackendrefactor.post.dto.response.PostsSliceResponse;
 import com.hibitbackendrefactor.profile.domain.Profile;
 import com.hibitbackendrefactor.profile.domain.ProfileRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +18,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
@@ -27,6 +33,7 @@ import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_�
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Slf4j
 class PostServiceTest extends IntegrationTestSupport {
@@ -168,6 +175,128 @@ class PostServiceTest extends IntegrationTestSupport {
         // then
         assertThat(viewCount + expectedIncreasedViewCount).isEqualTo(updatedViewCount);
     }
+
+    @DisplayName("주어진 쿼리로 정확히 한 개의 게시글을 검색할 수 있다.")
+    @Test
+    void 주어진_쿼리로_정확히_한_개의_게시글을_검색할_수_있다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile 팬시_프로필 = 팬시_프로필(member);
+        Profile profile = profileRepository.save(팬시_프로필);
+        memberRepository.save(팬시);
+
+        Post 게시글_1 = 프로젝트_해시테크(profile.getMember());
+        Post 게시글_2 = 오스틴리_전시회(profile.getMember());
+        postRepository.saveAll(List.of(게시글_1, 게시글_2));
+
+        String query = "오스틴리";
+
+        // when
+        PostsSliceResponse myPosts = postService.searchSlickWithQuery(query,
+                PageRequest.of(0, 3, DESC, "created_date_time"));
+        PostsCountResponse response = postService.countPostWithQuery(query);
+
+        // then
+        assertAll(
+                () -> assertThat(myPosts.getPosts()).usingRecursiveComparison()
+                        .comparingOnlyFields("title", "content")
+                        .isEqualTo(List.of(PostResponse.from(게시글_2))),
+                () -> assertThat(response.getTotalPostCount()).isEqualTo(1)
+        );
+     }
+
+    @DisplayName("주어진 쿼리로 여러 개의 게시글을 검색할 수 있다. ")
+    @Test
+    void 주어진_쿼키로_여러_개의_게시글을_검색할_수_있다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile 팬시_프로필 = 팬시_프로필(member);
+        Profile profile = profileRepository.save(팬시_프로필);
+        memberRepository.save(팬시);
+
+        Post 게시글_1 = 프로젝트_해시테크(profile.getMember());
+        Post 게시글_2 = 프로젝트_해시테크_2(profile.getMember());
+        postRepository.saveAll(List.of(게시글_1, 게시글_2));
+
+        // when
+        PostsSliceResponse response = postService.searchSlickWithQuery("프로젝트",
+                PageRequest.of(0, 3, DESC, "created_date_time"));
+
+        // then
+        assertAll(
+                () -> assertThat(response.getPosts()).usingRecursiveComparison()
+                        .comparingOnlyFields("title", "content")
+                        .isEqualTo(List.of(PostResponse.from(게시글_2), PostResponse.from(게시글_1)))
+        );
+    }
+
+    @DisplayName("주어진 쿼리로 제목과 본문 안에서 검색이 가능하다.")
+    @Test
+    void 주어진_쿼리로_제목과_본문_안에서_검색이_가능하다() {
+        // given
+        Member 팬시 = 팬시();
+        memberRepository.save(팬시);
+        Member member = memberRepository.getById(팬시.getId());
+
+        Profile 팬시_프로필 = 팬시_프로필(member);
+        Profile profile = profileRepository.save(팬시_프로필);
+        memberRepository.save(팬시);
+
+        Post post1 = 프로젝트_해시테크(profile.getMember());
+        Post post2 = 프로젝트_해시테크_2(profile.getMember());
+        Post post3 = 오스틴리_전시회(profile.getMember());
+        postRepository.saveAll(List.of(post1, post2, post3));
+
+        String query = "프로젝트";
+        // when
+        PostsSliceResponse myPosts = postService.searchSlickWithQuery(query,
+                PageRequest.of(0, 3, DESC, "created_date_time"));
+        PostsCountResponse response = postService.countPostWithQuery(query);
+
+        // then
+        assertAll(
+                () -> assertThat(myPosts.getPosts()).usingRecursiveComparison()
+                        .comparingOnlyFields("title", "content")
+                        .isEqualTo(List.of(PostResponse.from(post1), PostResponse.from(post2))),
+                () -> assertThat(response.getTotalPostCount()).isEqualTo(2)
+        );
+     }
+
+     @DisplayName("인젝션 위험 쿼리는 빈 쿼리로 대체한다. (lastPage는 true로 반환된다)")
+     @ParameterizedTest
+     @CsvSource(value = {"select", "insert", "update", "delete", "()"})
+     void 인젝션_위험_쿼리는_빈_쿼리로_대체한다(String query) {
+         // given
+         Member 팬시 = 팬시();
+         memberRepository.save(팬시);
+         Member member = memberRepository.getById(팬시.getId());
+
+         Profile 팬시_프로필 = 팬시_프로필(member);
+         Profile profile = profileRepository.save(팬시_프로필);
+         memberRepository.save(팬시);
+
+         Post post1 = 프로젝트_해시테크(profile.getMember());
+         Post post2 = 프로젝트_해시테크_2(profile.getMember());
+         Post post3 = 오스틴리_전시회(profile.getMember());
+         postRepository.saveAll(List.of(post1, post2, post3));
+
+         // when
+         PostsSliceResponse myPosts = postService.searchSlickWithQuery(query,
+                 PageRequest.of(0, 3, DESC, "created_date_time"));
+         PostsCountResponse response = postService.countPostWithQuery(query);
+
+         // then
+         assertAll(
+                 () -> assertThat(myPosts.isLastPage()).isEqualTo(true),
+                 () -> assertThat(response.getTotalPostCount()).isEqualTo(3)
+         );
+      }
 
     private static Stream<Arguments> argsOfFindPostViewCount() {
         int today = LocalDateTime.now().getDayOfMonth();

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
@@ -11,15 +11,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
 import java.util.Optional;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
-import static com.hibitbackendrefactor.common.fixtures.PostFixtures.프로젝트_해시테크;
+import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
 import static com.hibitbackendrefactor.common.fixtures.ProfileFixtures.팬시_프로필;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @ActiveProfiles("test")
 @Transactional
@@ -34,11 +42,16 @@ class PostRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private PostRepository postRepository;
 
+    @PersistenceContext
+    private EntityManager em;
+
     private Member member;
 
     private Profile profile;
 
-    private Post post;
+    private Post post0;
+    private Post post1;
+    private Post post2;
 
     @BeforeEach
     void setUp() {
@@ -46,15 +59,17 @@ class PostRepositoryTest extends IntegrationTestSupport {
         memberRepository.save(member);
         profile = 팬시_프로필(member);
         profileRepository.save(profile);
-        post = 프로젝트_해시테크(member);
-        postRepository.save(post);
+        post0 = 오스틴리_전시회(member);
+        post1 = 프로젝트_해시테크(member);
+        post2 = 프로젝트_해시테크_2(member);
+        postRepository.saveAll(List.of(post0, post1, post2));
     }
 
     @DisplayName("게시글과 회원 테이블이 정상적으로 매핑이 된다.")
     @Test
     void 게시글과_회원_테이블이_정상적으로_매핑이_된다() {
         // given
-        Post foundPost = postRepository.findById(post.getId())
+        Post foundPost = postRepository.findById(post1.getId())
                 .orElseThrow(NotFoundPostException::new);
 
         // when & then
@@ -65,7 +80,7 @@ class PostRepositoryTest extends IntegrationTestSupport {
     @Test
     void 특정_회원_ID에_해당하는_게시글을_찾는다() {
         // given
-        Long memberId = post.getMember().getId();
+        Long memberId = post1.getMember().getId();
 
         // when
         Optional<Post> actual = postRepository.findByMemberId(memberId);
@@ -74,5 +89,25 @@ class PostRepositoryTest extends IntegrationTestSupport {
         assertThat(actual).isPresent();
         Post foundPost = actual.get();
         assertThat(foundPost.getMember().getId()).isEqualTo(memberId);
+    }
+    @DisplayName("특정 쿼리에 부합하는 글의 개수를 가져온다.")
+    @Test
+    void findPostPagesByQuery() {
+        // given
+        Page<Post> result = postRepository.findPostPagesByQuery(PageRequest.of(0, 3, DESC, "created_date_time"), "");
+
+        // when & then
+        assertThat(result.getTotalElements()).isEqualTo(3L);
+    }
+
+    @DisplayName("특정 쿼리에 부합하는 게시글을 최신순으로 가져온다.")
+    @Test
+    void findPostSlicePageByQuery() {
+        // given
+        Slice<Post> result = postRepository.findPostSlicePageByQuery(PageRequest.of(0, 2, DESC, "created_date_time"), "");
+
+        // when & then
+        assertThat(result.getContent()).containsExactly(post2, post1);
+        assertThat(result.isLast()).isEqualTo(false);
     }
 }

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
@@ -90,6 +90,36 @@ class PostRepositoryTest extends IntegrationTestSupport {
         Post foundPost = actual.get();
         assertThat(foundPost.getMember().getId()).isEqualTo(memberId);
     }
+
+    @DisplayName("신규로 등록된 게시글을 최신순으로 모두 조회한다.")
+    @Test
+    void findAllByOrderByCreatedDateTimeDesc() {
+        // given
+        List<Post> posts = postRepository.findAllByOrderByCreatedDateTimeDesc();
+
+        // when & then
+        assertThat(posts)
+                .extracting(Post::getTitle, Post::getContent)
+                .containsExactly(
+                        tuple(posts.get(0).getTitle(), posts.get(0).getContent()),
+                        tuple(posts.get(1).getTitle(), posts.get(1).getContent()),
+                        tuple(posts.get(2).getTitle(), posts.get(2).getContent())
+                );
+    }
+    
+    @DisplayName("특정 게시글의 viewCount 를 1 증가시킨다.")
+    @Test
+    void updateViewCount() {
+        // given
+        int initViewCount = postRepository.findById(post1.getId()).get().getViewCount();
+        postRepository.updateViewCount(post1.getId());
+        em.clear();
+        int viewCount = postRepository.findById(post1.getId()).get().getViewCount();
+
+        // when & then
+        assertThat(initViewCount + 1).isEqualTo(viewCount);
+    }
+
     @DisplayName("특정 쿼리에 부합하는 글의 개수를 가져온다.")
     @Test
     void findPostPagesByQuery() {

--- a/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/domain/PostRepositoryTest.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.List;
-import java.util.Optional;
 
 import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
 import static com.hibitbackendrefactor.common.fixtures.PostFixtures.*;
@@ -76,22 +75,7 @@ class PostRepositoryTest extends IntegrationTestSupport {
         Assertions.assertThat(foundPost.getMember().getId()).isNotNull();
     }
 
-    @DisplayName("특정 회원 ID에 해당하는 게시글을 찾는다.")
-    @Test
-    void 특정_회원_ID에_해당하는_게시글을_찾는다() {
-        // given
-        Long memberId = post1.getMember().getId();
-
-        // when
-        Optional<Post> actual = postRepository.findByMemberId(memberId);
-
-        // then
-        assertThat(actual).isPresent();
-        Post foundPost = actual.get();
-        assertThat(foundPost.getMember().getId()).isEqualTo(memberId);
-    }
-
-    @DisplayName("신규로 등록된 게시글을 최신순으로 모두 조회한다.")
+    @DisplayName("신규로 등록된 게시글을 최신순으로 모두 가져온다.")
     @Test
     void findAllByOrderByCreatedDateTimeDesc() {
         // given
@@ -106,7 +90,7 @@ class PostRepositoryTest extends IntegrationTestSupport {
                         tuple(posts.get(2).getTitle(), posts.get(2).getContent())
                 );
     }
-    
+
     @DisplayName("특정 게시글의 viewCount 를 1 증가시킨다.")
     @Test
     void updateViewCount() {


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

검색 기능 구현 및 Slice 를 도입하여 기존 대비 성능을 조금 개선했습니다.

> 아래 Issue를 통해 어떤 작업을 진행했는지 확인하실 수 있습니다.

Closes #52 

## 성능 테스트 결과

> 동시 접속 사용자 100명을 기준으로 1초동안 100번 반복하여(총 10,000번) 테스트를 진행했습니다.

### Slice 적용 전

1. 요약 보고서

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/88f0935d-fc33-48e0-a656-407378ab7805)

2. Transactional per Second

<img width="600" alt="스크린샷 2024-02-01 오후 8 25 07" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/5bba13ef-e526-4ae6-bcd4-bb3f20541d96">

### Slice 적용 후

1. 요약 보고서

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/80a9ea0b-d607-4bf0-951f-98bd50229344)

2. Transactional per Second

<img width="600" alt="스크린샷 2024-02-01 오후 8 25 15" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/a027f88f-dcfc-4217-aba7-b27228e040af">

### 정리

Page 대신 Slice 적용한 결과, 총 처리 시간은  38초 -> **32초**로 6초 단축되었고, TPS는 약 267 -> **309**로 증가되었으며, 최고 TPS는 320 -> **360**으로 개선되었습니다.

## Jacoco 결과

![](https://github.com/hibit-team/hibit-backend-improved/assets/83820185/1e91ce05-227d-4fa3-b024-6d6ffd54657f)
