### PR TITLE
모든 API 엔드포인트에 일관된 일관된 응답 포맷을 제공하도록 반환하는 값 수정

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -51,3 +51,10 @@ include::{snippets}/auth/generate/renewalAccessToken/success/http-response.adoc[
 
 ==== HTTP Response
 include::{snippets}/auth/generate/renewalAccessToken/fail/isUnauthorized/http-response.adoc[]
+
+=== 로그아웃 시 리프레시 토큰 무효화
+==== HTTP Request
+include::{snippets}/auth/logout/success/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/auth/logout/success/http-response.adoc[]

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -10,6 +10,8 @@ include::{snippets}/posts/save/success/request-fields.adoc[]
 ==== HTTP Response
 include::{snippets}/posts/save/success/http-response.adoc[]
 
+==== Response Fields
+include::{snippets}/posts/save/success/response-fields.adoc[]
 
 === 게시글 상세 조회
 ==== HTTP Request

--- a/src/main/java/com/hibitbackendrefactor/auth/application/AuthService.java
+++ b/src/main/java/com/hibitbackendrefactor/auth/application/AuthService.java
@@ -80,7 +80,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void deleteToken(Long id) {
+    public void deleteToken(final Long id) {
         oAuthTokenRepository.deleteAllByMemberId(id);
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepository.java
+++ b/src/main/java/com/hibitbackendrefactor/auth/domain/OAuthTokenRepository.java
@@ -19,5 +19,5 @@ public interface OAuthTokenRepository extends JpaRepository<OAuthToken, Long> {
         return findByMemberId(memberId)
                 .orElseThrow(NotFoundOAuthTokenException::new);
     }
-    void deleteAllByMemberId(Long memberId);
+    void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/hibitbackendrefactor/auth/dto/LoginMember.java
+++ b/src/main/java/com/hibitbackendrefactor/auth/dto/LoginMember.java
@@ -7,7 +7,7 @@ public class LoginMember {
     public LoginMember() {
     }
 
-    public LoginMember(Long id) {
+    public LoginMember(final Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/hibitbackendrefactor/global/ApiResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/global/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.hibitbackendrefactor.global;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final Meta meta;
+    private final T data;
+
+    public ApiResponse(int code, String message, T data) {
+        this.meta = new Meta(code, message);
+        this.data = data;
+    }
+
+    @Getter
+    private static class Meta {
+        private final int code;
+        private final String message;
+
+        public Meta(int code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/hibitbackendrefactor/global/ApiResponse.java
+++ b/src/main/java/com/hibitbackendrefactor/global/ApiResponse.java
@@ -1,6 +1,8 @@
 package com.hibitbackendrefactor.global;
 
+import com.hibitbackendrefactor.global.error.dto.ErrorResponse;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ApiResponse<T> {
@@ -11,6 +13,42 @@ public class ApiResponse<T> {
     public ApiResponse(int code, String message, T data) {
         this.meta = new Meta(code, message);
         this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(httpStatus.value(), message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.getReasonPhrase(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+
+    public static <T> ApiResponse<T> created(T data) {
+        return of(HttpStatus.CREATED, data);
+    }
+
+    public static <T> ApiResponse<T> noContent() {
+        return of(HttpStatus.NO_CONTENT, null);
+    }
+
+    public static ApiResponse<ErrorResponse> badRequest(ErrorResponse errorResponse) {
+        return of(HttpStatus.BAD_REQUEST, errorResponse.getMessage(), null);
+    }
+
+    public static ApiResponse<ErrorResponse> UnAuthorized(ErrorResponse errorResponse) {
+        return of(HttpStatus.UNAUTHORIZED, errorResponse.getMessage(), null);
+    }
+
+    public static ApiResponse<ErrorResponse> NotFound(ErrorResponse errorResponse) {
+        return of(HttpStatus.NOT_FOUND, errorResponse.getMessage(), null);
+    }
+
+    public static ApiResponse<ErrorResponse> internalServerError(ErrorResponse errorResponse) {
+        return of(HttpStatus.INTERNAL_SERVER_ERROR, errorResponse.getMessage(), null);
     }
 
     @Getter

--- a/src/main/java/com/hibitbackendrefactor/member/presentation/MemberController.java
+++ b/src/main/java/com/hibitbackendrefactor/member/presentation/MemberController.java
@@ -2,9 +2,11 @@ package com.hibitbackendrefactor.member.presentation;
 
 import com.hibitbackendrefactor.auth.dto.LoginMember;
 import com.hibitbackendrefactor.auth.presentation.AuthenticationPrincipal;
+import com.hibitbackendrefactor.global.ApiResponse;
 import com.hibitbackendrefactor.member.application.MemberService;
 import com.hibitbackendrefactor.member.dto.MemberResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +23,10 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> findMe(@AuthenticationPrincipal final LoginMember loginMember) {
+    public ResponseEntity<ApiResponse<MemberResponse>> findMe(@AuthenticationPrincipal final LoginMember loginMember) {
         MemberResponse response = memberService.findById(loginMember.getId());
-        return ResponseEntity.ok(response);
+        ApiResponse<MemberResponse> apiResponse = ApiResponse.ok(response);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
+++ b/src/main/java/com/hibitbackendrefactor/post/application/PostService.java
@@ -46,14 +46,12 @@ public class PostService {
     }
 
     @Transactional
-    public Long save(final Long memberId, final PostCreateRequest request) {
-        validateMember(memberId);
-        Member foundMember = memberRepository.getById(memberId);
-
+    public PostDetailResponse save(final LoginMember loginMember, final PostCreateRequest request) {
+        validateMember(loginMember.getId());
+        Member foundMember = memberRepository.getById(loginMember.getId());
         Post savedPost = request.toEntity(foundMember, request);
         postRepository.save(savedPost);
-
-        return savedPost.getId();
+        return PostDetailResponse.of(savedPost, loginMember);
     }
 
     private void validateMember(final Long memberId) {

--- a/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
+++ b/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
@@ -33,17 +33,18 @@ public class PostController {
     }
 
     @PostMapping(path = "/api/posts/new")
-    public ResponseEntity<ApiResponse<Void>> save(@AuthenticationPrincipal final LoginMember loginMember
+    public ResponseEntity<ApiResponse<PostDetailResponse>> save(@AuthenticationPrincipal final LoginMember loginMember
             , @Valid @RequestBody final PostCreateRequest request) {
         PostDetailResponse response = postService.save(loginMember, request);
-        ApiResponse apiResponse = ApiResponse.created(response);
+        ApiResponse<PostDetailResponse> apiResponse = ApiResponse.created(response);
         return new ResponseEntity<>(apiResponse, HttpStatus.CREATED);
     }
 
     @GetMapping(path = "/api/posts")
-    public ResponseEntity<PostsResponse> findAll() {
+    public ResponseEntity<ApiResponse<PostsResponse>> findAll() {
         PostsResponse responses = postService.findAll();
-        return ResponseEntity.ok(responses);
+        ApiResponse apiResponse = ApiResponse.ok(responses);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @GetMapping(path = "/api/posts/{id}")

--- a/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
+++ b/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
@@ -43,45 +43,53 @@ public class PostController {
     @GetMapping(path = "/api/posts")
     public ResponseEntity<ApiResponse<PostsResponse>> findAll() {
         PostsResponse responses = postService.findAll();
-        ApiResponse apiResponse = ApiResponse.ok(responses);
+        ApiResponse<PostsResponse> apiResponse = ApiResponse.ok(responses);
         return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @GetMapping(path = "/api/posts/{id}")
-    public ResponseEntity<PostDetailResponse> findPost(@PathVariable(name = "id") final Long postId,
-                                                       @AuthenticationPrincipal final LoginMember loginMember,
-                                                       @CookieValue(value = "viewedPost", required = false, defaultValue = "") final String postLog) {
+    public ResponseEntity<ApiResponse<PostDetailResponse>> findPost(@PathVariable(name = "id") final Long postId,
+                                                                    @AuthenticationPrincipal final LoginMember loginMember,
+                                                                    @CookieValue(value = "viewedPost", required = false, defaultValue = "") final String postLog) {
         PostDetailResponse response = postService.findPost(postId, loginMember, postLog);
         String updatedLog = postService.updatePostLog(postId, postLog);
         ResponseCookie responseCookie = ResponseCookie.from("viewedPost", updatedLog).maxAge(86400L).build();
-        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(response);
+
+        ApiResponse<PostDetailResponse> apiResponse = ApiResponse.ok(response);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(apiResponse);
     }
 
     @GetMapping(path = "/api/posts/count")
-    public ResponseEntity<PostsCountResponse> searchPostCount(@RequestParam @Nullable String query) {
+    public ResponseEntity<ApiResponse<PostsCountResponse>> searchPostCount(@RequestParam @Nullable String query) {
         PostsCountResponse postsCountResponse = postService.countPostWithQuery(query);
-        return ResponseEntity.ok(postsCountResponse);
+        ApiResponse<PostsCountResponse> apiResponse = ApiResponse.ok(postsCountResponse);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @GetMapping(path = "/api/posts/search")
-    public ResponseEntity<PostsSliceResponse> searchSlicePosts(@RequestParam @Nullable String query,
-                                                               @PageableDefault(sort = "created_date_time", direction = DESC) Pageable pageable) {
+    public ResponseEntity<ApiResponse<PostsSliceResponse>> searchSlicePosts(@RequestParam @Nullable String query,
+                                                                            @PageableDefault(sort = "created_date_time", direction = DESC) Pageable pageable) {
         PostsSliceResponse postsSliceResponse = postService.searchSlickWithQuery(query, pageable);
-        return ResponseEntity.ok(postsSliceResponse);
+        ApiResponse<PostsSliceResponse> apiResponse = ApiResponse.ok(postsSliceResponse);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @PatchMapping(path = "/api/posts/{id}")
-    public ResponseEntity<PostDetailResponse> update(@AuthenticationPrincipal final LoginMember loginMember,
-                                                     @PathVariable(name = "id") final Long postId,
-                                                     @Valid @RequestBody final PostUpdateRequest request) {
+    public ResponseEntity<ApiResponse<PostDetailResponse>> update(@AuthenticationPrincipal final LoginMember loginMember,
+                                                                  @PathVariable(name = "id") final Long postId,
+                                                                  @Valid @RequestBody final PostUpdateRequest request) {
         postService.update(loginMember.getId(), postId, request.toServiceRequest());
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        ApiResponse<PostDetailResponse> apiResponse = ApiResponse.noContent();
+        return new ResponseEntity<>(apiResponse, HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping(path = "/api/posts/{id}")
-    public ResponseEntity<Void> delete(@AuthenticationPrincipal final LoginMember loginMember,
-                                       @PathVariable(name = "id") final Long postId) {
+    public ResponseEntity<ApiResponse<Void>> delete(@AuthenticationPrincipal final LoginMember loginMember,
+                                                    @PathVariable(name = "id") final Long postId) {
         postService.delete(loginMember.getId(), postId);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        ApiResponse<Void> apiResponse = ApiResponse.noContent();
+        return new ResponseEntity<>(apiResponse, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
+++ b/src/main/java/com/hibitbackendrefactor/post/presentation/PostController.java
@@ -2,6 +2,7 @@ package com.hibitbackendrefactor.post.presentation;
 
 import com.hibitbackendrefactor.auth.dto.LoginMember;
 import com.hibitbackendrefactor.auth.presentation.AuthenticationPrincipal;
+import com.hibitbackendrefactor.global.ApiResponse;
 import com.hibitbackendrefactor.post.application.PostService;
 import com.hibitbackendrefactor.post.dto.request.PostCreateRequest;
 import com.hibitbackendrefactor.post.dto.request.PostUpdateRequest;
@@ -19,7 +20,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.net.URI;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
@@ -33,10 +33,11 @@ public class PostController {
     }
 
     @PostMapping(path = "/api/posts/new")
-    public ResponseEntity<Void> save(@AuthenticationPrincipal final LoginMember loginMember
+    public ResponseEntity<ApiResponse<Void>> save(@AuthenticationPrincipal final LoginMember loginMember
             , @Valid @RequestBody final PostCreateRequest request) {
-        Long postId = postService.save(loginMember.getId(), request);
-        return ResponseEntity.created(URI.create("/posts/" + postId)).build();
+        PostDetailResponse response = postService.save(loginMember, request);
+        ApiResponse apiResponse = ApiResponse.created(response);
+        return new ResponseEntity<>(apiResponse, HttpStatus.CREATED);
     }
 
     @GetMapping(path = "/api/posts")

--- a/src/main/java/com/hibitbackendrefactor/profile/application/ProfileService.java
+++ b/src/main/java/com/hibitbackendrefactor/profile/application/ProfileService.java
@@ -27,7 +27,7 @@ public class ProfileService {
     }
 
     @Transactional
-    public Long save(final Long memberId, final ProfileCreateRequest request) {
+    public ProfileResponse save(final Long memberId, final ProfileCreateRequest request) {
         validateExistByNickname(request.getNickname());
         if (profileRepository.existsByMemberId(memberId)) {
             throw new InvalidProfileAlreadyException("프로필이 이미 존재합니다.");
@@ -37,7 +37,7 @@ public class ProfileService {
         Profile savedProfile = profileRepository.save(profile);
 
         updateMemberInfo(foundMember, savedProfile);
-        return savedProfile.getId();
+        return ProfileResponse.of(savedProfile);
     }
 
     private Profile createProfile(final ProfileCreateRequest request, final Member foundMember) {

--- a/src/main/java/com/hibitbackendrefactor/profile/presentation/ProfileController.java
+++ b/src/main/java/com/hibitbackendrefactor/profile/presentation/ProfileController.java
@@ -3,6 +3,7 @@ package com.hibitbackendrefactor.profile.presentation;
 
 import com.hibitbackendrefactor.auth.dto.LoginMember;
 import com.hibitbackendrefactor.auth.presentation.AuthenticationPrincipal;
+import com.hibitbackendrefactor.global.ApiResponse;
 import com.hibitbackendrefactor.profile.application.ProfileService;
 import com.hibitbackendrefactor.profile.domain.PersonalityType;
 import com.hibitbackendrefactor.profile.dto.request.ProfileCreateRequest;
@@ -14,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,35 +27,40 @@ public class ProfileController {
     }
 
     @PostMapping("/api/profiles/new")
-    public ResponseEntity<Void> saveMyProfile(@AuthenticationPrincipal final LoginMember loginMember,
-                                              @Valid @RequestBody final ProfileCreateRequest request) {
-        Long profileId = profileService.save(loginMember.getId(), request);
-        return ResponseEntity.created(URI.create("/api/profiles/" + profileId)).build();
+    public ResponseEntity<ApiResponse<ProfileResponse>> saveMyProfile(@AuthenticationPrincipal final LoginMember loginMember,
+                                                          @Valid @RequestBody final ProfileCreateRequest request) {
+        ProfileResponse profileResponse = profileService.save(loginMember.getId(), request);
+        ApiResponse<ProfileResponse> apiResponse = ApiResponse.created(profileResponse);
+        return new ResponseEntity<>(apiResponse, HttpStatus.CREATED);
     }
 
     @GetMapping("/api/profiles/personalities")
-    public ResponseEntity<List<PersonalityType>> getAvailablePersonalities() {
+    public ResponseEntity<ApiResponse<List<PersonalityType>>> getAvailablePersonalities() {
         List<PersonalityType> personalities = Arrays.asList(PersonalityType.values());
-        return ResponseEntity.ok(personalities);
+        ApiResponse<List<PersonalityType>> apiResponse = ApiResponse.ok(personalities);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @GetMapping("/api/profiles/me")
-    public ResponseEntity<ProfileResponse> findMyProfile(@AuthenticationPrincipal final LoginMember loginMember) {
-        ProfileResponse response = profileService.findMyProfile(loginMember.getId());
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<ProfileResponse>> findMyProfile(@AuthenticationPrincipal final LoginMember loginMember) {
+        ProfileResponse profileResponse = profileService.findMyProfile(loginMember.getId());
+        ApiResponse<ProfileResponse> apiResponse = ApiResponse.ok(profileResponse);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @GetMapping("/api/profiles/other/{id}")
-    public ResponseEntity<ProfileOtherResponse> findOtherProfile(@AuthenticationPrincipal final LoginMember loginMember,
+    public ResponseEntity<ApiResponse<ProfileOtherResponse>> findOtherProfile(@AuthenticationPrincipal final LoginMember loginMember,
                                                                  @PathVariable(name = "id") final Long otherMemberId) {
-        ProfileOtherResponse response = profileService.findOtherProfile(otherMemberId);
-        return ResponseEntity.ok(response);
+        ProfileOtherResponse profileOtherResponse = profileService.findOtherProfile(otherMemberId);
+        ApiResponse<ProfileOtherResponse> apiResponse = ApiResponse.ok(profileOtherResponse);
+        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
     @PutMapping("/api/profiles/me")
-    public ResponseEntity<Void> update(@AuthenticationPrincipal final LoginMember loginMember,
+    public ResponseEntity<ApiResponse<Void>> update(@AuthenticationPrincipal final LoginMember loginMember,
                                        @Valid @RequestBody final ProfileUpdateRequest request) {
         profileService.update(loginMember.getId(), request);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        ApiResponse<Void> apiResponse = ApiResponse.noContent();
+        return new ResponseEntity<>(apiResponse, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
+++ b/src/test/java/com/hibitbackendrefactor/common/fixtures/PostFixtures.java
@@ -4,14 +4,22 @@ import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.post.domain.Post;
 import com.hibitbackendrefactor.post.domain.PostStatus;
 import com.hibitbackendrefactor.post.domain.TogetherActivity;
+import com.hibitbackendrefactor.post.dto.response.PostDetailResponse;
 
 import java.time.LocalDateTime;
 
-import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.팬시;
+import static com.hibitbackendrefactor.common.fixtures.MemberFixtures.*;
+import static com.hibitbackendrefactor.post.dto.response.PostResponse.AttendanceAndTogetherActivity;
 
 public class PostFixtures {
 
+
     /* 게시글1 : 해시태크 */
+    public static final Long 게시글_ID1 = 1L;
+
+    public static final Long 로그인한_사용자_ID = 1L;
+
+    public static final String 게시글_작성한_사용자_닉네임 = "팬시";
     public static final String 게시글제목1 = "프로젝트_해시테크";
     public static final String 게시글내용1 = "프로젝트 해시 태크(http://projecthashtag.net/) 보러가실 분 있으면 아래 댓글 남겨주세요~";
 
@@ -24,6 +32,7 @@ public class PostFixtures {
 
     public static final String 게시글이미지1 = "postImage1.png";
     public static final PostStatus 모집상태1 = PostStatus.HOLDING;
+    public static final int 게시글_조회수1 = 0;
 
     /* 게시글1-2 : 해시태크-2 */
     public static final String 게시글제목1_2 = "프로젝트_해시테크";
@@ -55,6 +64,10 @@ public class PostFixtures {
     public static final String 게시글이미지2 = "postImage2.png";
 
     public static final PostStatus 모집상태2 = PostStatus.HOLDING;
+
+    public static PostDetailResponse 프로필_등록_응답() {
+        return new PostDetailResponse(게시글_ID1, 로그인한_사용자_ID, 게시글_작성한_사용자_닉네임, 게시글제목1, 게시글내용1, 전시회제목1, AttendanceAndTogetherActivity(전시관람인원1, 함께하고싶은활동1), 전시관람희망날짜1, 오픈채팅방Url1, 모집상태1, 게시글이미지1, 게시글_조회수1);
+    }
 
     public static Post 프로젝트_해시테크_2(Member member) {
         return Post.builder()

--- a/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/application/PostServiceTest.java
@@ -1,6 +1,7 @@
 package com.hibitbackendrefactor.post.application;
 
 import com.hibitbackendrefactor.IntegrationTestSupport;
+import com.hibitbackendrefactor.auth.dto.LoginMember;
 import com.hibitbackendrefactor.member.domain.Member;
 import com.hibitbackendrefactor.member.domain.MemberRepository;
 import com.hibitbackendrefactor.post.domain.Post;
@@ -76,23 +77,24 @@ class PostServiceTest extends IntegrationTestSupport {
         Profile 팬시_프로필 = 팬시_프로필(member);
         profileRepository.save(팬시_프로필);
 
-        // when
         PostCreateRequest request = getPostCreateRequest();
-        Long newPostId = postService.save(팬시_프로필.getMember().getId(), request);
-        Post actual = postRepository.findById(newPostId).orElseThrow();
+
+        // when
+        LoginMember loginMember = new LoginMember(팬시.getId());
+        PostDetailResponse response = postService.save(loginMember, request);
+        Post actual = postRepository.findById(response.getId()).orElseThrow();
 
         // then
-        assertThat(newPostId).isNotNull();
+        assertThat(response.getTitle()).isNotNull();
         assertAll(
-                () -> assertEquals(게시글제목1, actual.getTitle()),
-                () -> assertEquals(게시글내용1, actual.getContent()),
-                () -> assertEquals(전시회제목1, actual.getExhibition()),
-                () -> assertEquals(전시관람인원1, actual.getExhibitionAttendance()),
-                () -> assertEquals(전시관람희망날짜1, actual.getPossibleTime()),
-                () -> assertEquals(오픈채팅방Url1, actual.getOpenChatUrl()),
-                () -> assertEquals(함께하고싶은활동1, actual.getTogetherActivity()),
-                () -> assertEquals(전시관람인원1, actual.getExhibitionAttendance()),
-                () -> assertEquals(게시글이미지1, actual.getImageName())
+                () -> assertEquals(request.getTitle(), actual.getTitle()),
+                () -> assertEquals(request.getContent(), actual.getContent()),
+                () -> assertEquals(request.getExhibition(), actual.getExhibition()),
+                () -> assertEquals(request.getExhibitionAttendance(), actual.getExhibitionAttendance()),
+                () -> assertEquals(request.getPossibleTime(), actual.getPossibleTime()),
+                () -> assertEquals(request.getOpenChatUrl(), actual.getOpenChatUrl()),
+                () -> assertEquals(request.getTogetherActivity(), actual.getTogetherActivity()),
+                () -> assertEquals(request.getImageName(), actual.getImageName())
         );
     }
 

--- a/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
@@ -31,7 +31,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -136,7 +135,7 @@ class PostControllerTest extends ControllerTestSupport {
         given(postService.findAll()).willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/posts")
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -198,7 +197,7 @@ class PostControllerTest extends ControllerTestSupport {
         when(postService.countPostWithQuery(any())).thenReturn(countResponse);
 
         // then
-        mockMvc.perform(get("/api/posts/count?query=제목|내용")
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/count?query=제목|내용")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -222,7 +221,7 @@ class PostControllerTest extends ControllerTestSupport {
         when(postService.searchSlickWithQuery(any(), any())).thenReturn(pagePostsResponse);
 
         // then
-        mockMvc.perform(get("/api/posts/search?query=제목&size=2&page=0")
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/search?query=제목&size=2&page=0")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -244,7 +243,7 @@ class PostControllerTest extends ControllerTestSupport {
         when(postService.searchSlickWithQuery(any(), any())).thenReturn(pagePostsResponse);
 
         // then
-        mockMvc.perform(get("/api/posts/search?query=제목2|제목1&size=2&page=0")
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/search?query=제목2|제목1&size=2&page=0")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -267,7 +266,7 @@ class PostControllerTest extends ControllerTestSupport {
         when(postService.searchSlickWithQuery(any(), any())).thenReturn(pagePostsResponse);
 
         // then
-        mockMvc.perform(get("/api/posts/search?query=제목2&제목1&size=2&page=0")
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/search?query=제목2&제목1&size=2&page=0")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -301,7 +300,7 @@ class PostControllerTest extends ControllerTestSupport {
                 .build();
 
         // when & then
-        mockMvc.perform(patch("/api/posts/{postId}", postId)
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/api/posts/{postId}", postId)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
@@ -325,7 +324,7 @@ class PostControllerTest extends ControllerTestSupport {
                 .update(any(), any(), any());
 
         // when
-        mockMvc.perform(delete("/api/posts/{postId}", postId)
+        mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/posts/{postId}", postId)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/hibitbackendrefactor/post/presentation/PostControllerTest.java
@@ -28,8 +28,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -79,8 +78,10 @@ class PostControllerTest extends ControllerTestSupport {
                 .postStatus(모집상태1)
                 .build();
 
+        given(postService.save(any(), any())).willReturn(프로필_등록_응답());
+
         // when & then
-        mockMvc.perform(post("/api/posts/new")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/posts/new")
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
@@ -101,7 +102,23 @@ class PostControllerTest extends ControllerTestSupport {
                                         fieldWithPath("openChatUrl").type(JsonFieldType.STRING).description("오픈 채팅방 URL 주소"),
                                         fieldWithPath("togetherActivity").type(JsonFieldType.STRING).optional().description("함께하고싶은 활동 타입(EAT | CAFE | ONLY | LATER)"),
                                         fieldWithPath("imageName").type(JsonFieldType.STRING).description("게시글 이미지"),
-                                        fieldWithPath("postStatus").type(JsonFieldType.STRING).optional().description("모집상태 타입(HOLDING | CANCELLED | COMPLETED)"))
+                                        fieldWithPath("postStatus").type(JsonFieldType.STRING).optional().description("모집상태 타입(HOLDING | CANCELLED | COMPLETED)")),
+                                responseFields(
+                                        fieldWithPath("meta.code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("meta.message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("게시글 ID"),
+                                        fieldWithPath("data.writerId").type(JsonFieldType.NUMBER).description("로그인한 사용자 ID"),
+                                        fieldWithPath("data.writerName").type(JsonFieldType.STRING).description("로그인한 사용자 닉네임"),
+                                        fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시글 제목"),
+                                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시글 내용"),
+                                        fieldWithPath("data.exhibition").type(JsonFieldType.STRING).description("전시회 제목"),
+                                        fieldWithPath("data.exhibitionAttendanceAndTogetherActivity").type(JsonFieldType.ARRAY).description("[ \"3인 관람\", \"맛집 가기\" ]"),
+                                        fieldWithPath("data.possibleTime").type(JsonFieldType.STRING).description("관람 희망 날짜"),
+                                        fieldWithPath("data.openChatUrl").type(JsonFieldType.STRING).description("오픈 채팅방 URL 주소"),
+                                        fieldWithPath("data.togetherActivity").type(JsonFieldType.STRING).optional().description("함께하고싶은 활동 타입(EAT | CAFE | ONLY | LATER)"),
+                                        fieldWithPath("data.imageName").type(JsonFieldType.STRING).description("게시글 이미지"),
+                                        fieldWithPath("data.postStatus").type(JsonFieldType.STRING).optional().description("모집상태 타입(HOLDING | CANCELLED | COMPLETED)"),
+                                        fieldWithPath("data.viewCount").type(JsonFieldType.NUMBER).description("게시글 조회수"))
                         )
                 )
                 .andExpect(status().isCreated());

--- a/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
+++ b/src/test/java/com/hibitbackendrefactor/profile/application/ProfileServiceTest.java
@@ -61,11 +61,11 @@ class ProfileServiceTest extends IntegrationTestSupport {
                 .build();
 
         // when
-        Long newProfileId = profileService.save(member.getId(), request);
+        ProfileResponse response = profileService.save(member.getId(), request);
         Profile savedProfile = profileRepository.findByMemberId(팬시.getId()).orElse(null);
 
         // then
-        assertThat(newProfileId).isNotNull();
+        assertThat(response).isNotNull();
         assertNotNull(savedProfile);
         assertEquals("devFancy", savedProfile.getNickname());
     }


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

- 자세한 내용은 이슈에 정리했습니다.
- 해당 태스크를 작업하면서, 일부 놓친 테스트코드에 대한 추가로 작성했습니다.
- 또한 프로필 등록과 게시글 등록에 대해 반환 값을 Id 가 아닌 등록한 정보로 수정했습니다.

## 주의사항

- Closes #61 

## 결과

- 기존) `data`에 있는 값만 보여줬음
- 변경) HttpStatus에 대한 `code`, `message` 정보를 같이 보여주도록 하였고, `data` 라는 객체 안에 보여줄 정보를 담아주도록 했음

```json
{
  "meta" : {
    "code" : 201,
    "message" : "Created"
  },
  "data" : {
    "id" : 1,
    "writerId" : 1,
    "writerName" : "팬시",
    "title" : "프로젝트_해시테크",
    "content" : "프로젝트 해시 태크(http://projecthashtag.net/) 보러가실 분 있으면 아래 댓글 남겨주세요~",
    "exhibition" : "PROJECT HASHTAG 2023 SELECTED ARTISTS",
    "exhibitionAttendanceAndTogetherActivity" : [ "3인 관람", "맛집 가기" ],
    "possibleTime" : "2024-03-02 17:20",
    "openChatUrl" : "http://projecthashtag.net/",
    "postStatus" : "HOLDING",
    "imageName" : "postImage1.png",
    "viewCount" : 0
  }
}
```

> 게시글 등록에 대한 HTTP Response

<img width="1000" alt="http_response" src="https://github.com/hibit-team/hibit-backend-improved/assets/83820185/f93aeb25-23a2-46fc-afcd-7895d75580bb">